### PR TITLE
Replace placeholder repository URL and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Series Correction Project (Seatek Sensor Data)
 
-[![Code Coverage](https://codecov.io/gh/yourusername/series-correction-project/branch/main/graph/badge.svg)](https://codecov.io/gh/yourusername/series-correction-project) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Code Coverage](https://codecov.io/gh/abhimehro/series_correction_project_updated/branch/main/graph/badge.svg)](https://codecov.io/gh/abhimehro/series_correction_project_updated) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 This project provides tools to automatically detect and correct discontinuities (such as jumps, gaps, or outliers) commonly found in time-series data from Seatek sensors. The goal is to produce cleaner, more reliable datasets for further analysis, suitable for integration with systems like NESST II.
 
@@ -62,9 +62,8 @@ Manually identifying and correcting these discontinuities is time-consuming, sub
 1. **Clone the repository:**
 
    ```bash
-   # TODO: Replace with your actual repository URL
-   git clone [https://github.com/yourusername/series-correction-project.git](https://github.com/yourusername/series-correction-project.git)
-   cd series-correction-project
+   git clone https://github.com/abhimehro/series_correction_project_updated.git
+   cd series_correction_project_updated
    ```
 
 2. **Create and activate a virtual environment (Recommended):**
@@ -190,7 +189,7 @@ The correction process involves sequentially detecting and correcting gaps, outl
 ## Project Structure
 
 ```
-series-correction-project/
+series_correction_project_updated/
 │
 ├── data/                     # Input data directory (MUST ADD SAMPLE S<series>_Y<index>.txt FILES HERE)
 │   └── S26_Y01.txt           # Example required input file format
@@ -266,7 +265,7 @@ This project is licensed under the MIT License. See the LICENSE file for details
 
 For questions or support, please open an issue on the GitHub repository:
 
-<https://github.com/yourusername/series-correction-project/issues>
+<https://github.com/abhimehro/series_correction_project_updated/issues>
 
 Alternatively, contact Abhi Mehrotra <AbhiMhrtr@pm.me>
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ LONG_DESCRIPTION = read_long_description()
 LONG_DESCRIPTION_CONTENT_TYPE = "text/markdown"
 AUTHOR = "Abhi Mehrotra"
 AUTHOR_EMAIL = "AbhiMhrtr@pm.me"
-URL = "https://github.com/yourusername/series-correction-project"
+URL = "https://github.com/abhimehro/series_correction_project_updated"
 LICENSE = "MIT"
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
I have replaced all occurrences of the placeholder repository URL and name with the actual ones in `README.md` and `setup.py`.

Key changes:
- In `README.md`, updated the Code Coverage badge, cloning instructions (removing the unnecessary markdown link syntax inside the bash block), the project structure diagram, and the issue tracker link.
- In `setup.py`, updated the `URL` metadata.
- Verified that no instances of the old placeholder remain in these files using `grep`.
- Ensured `setup.py` still compiles correctly.
- Attempted to run tests, but was limited by the lack of environment dependencies (e.g., pandas, mock) which could not be installed due to network restrictions in the sandbox. However, the changes are purely documentation/metadata and have no impact on the logic of the code.

---
*PR created automatically by Jules for task [2755497731522642673](https://jules.google.com/task/2755497731522642673) started by @abhimehro*