### PR TITLE
⚡ Bolt: Replace iterrows with itertuples for faster iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Pandas iteration optimization
+**Learning:** Iterating over Pandas DataFrames with `iterrows()` is a performance bottleneck due to Series creation overhead.
+**Action:** Replace `iterrows()` with `itertuples(index=False)` and use attribute access for significant speedup without loss of readability.

--- a/scripts/apply_refined_corrections.py
+++ b/scripts/apply_refined_corrections.py
@@ -116,10 +116,10 @@ if not identified_outliers_df.empty:
             raw_file_map[series_id][year_num] = raw_file_path
 
     # Iterate through the identified outliers
-    for idx, outlier_row in identified_outliers_df.iterrows():
-        outlier_year_pair_str = outlier_row["Year_Pair"]
-        outlier_sensor = outlier_row["Sensor"]
-        original_difference = outlier_row["Difference"]  # Difference from summary file
+    for outlier_row in identified_outliers_df.itertuples(index=False):
+        outlier_year_pair_str = outlier_row.Year_Pair
+        outlier_sensor = outlier_row.Sensor
+        original_difference = outlier_row.Difference  # Difference from summary file
 
         # Parse the Year_Pair string (e.g., "1996 (Y02) to 1995 (Y01)")
         pair_match = re.match(

--- a/scripts/generate_overview_table.py
+++ b/scripts/generate_overview_table.py
@@ -30,22 +30,22 @@ def main(correction_log_path, updated_averages_csv_path):
 
         # Dictionary for quick lookup of averages by (Series, Year_Num_YY)
         avg_lookup = {
-            (row["Series"], row["Year_Num_YY"]): {
-                "Beginning_Average": row["Beginning_Average"],
-                "End_Average": row["End_Average"],
+            (row.Series, row.Year_Num_YY): {
+                "Beginning_Average": row.Beginning_Average,
+                "End_Average": row.End_Average,
             }
-            for _, row in df_averages.iterrows()
+            for row in df_averages.itertuples(index=False)
         }
 
         # Sort the log for deterministic output
         df_log = df_log.sort_values(by=["Series", "Year_Pair_Outlier", "Sensor"])
 
-        for _, row in df_log.iterrows():
-            series = row["Series"]
-            year_pair_outlier_str = row["Year_Pair_Outlier"]
-            sensor = row["Sensor"]
-            original_difference = row["Original_Difference_Summary"]
-            calculated_level_shift = row["Calculated_Level_Shift"]
+        for row in df_log.itertuples(index=False):
+            series = row.Series
+            year_pair_outlier_str = row.Year_Pair_Outlier
+            sensor = row.Sensor
+            original_difference = row.Original_Difference_Summary
+            calculated_level_shift = row.Calculated_Level_Shift
 
             # Parse year pair string
             pair_match = re.match(


### PR DESCRIPTION
💡 **What:** Replaced pandas `.iterrows()` loops with `.itertuples(index=False)` in two script files (`apply_refined_corrections.py` and `generate_overview_table.py`). Updated the row access from dictionary-style keys to attribute access.
🎯 **Why:** Iterating over pandas DataFrames using `.iterrows()` is a known performance anti-pattern. It creates a new pandas Series for every single row, which is very slow. `itertuples(index=False)` returns namedtuples, which are much lighter weight and considerably faster to create and access.
📊 **Impact:** Expected significant performance improvement in scripts that iterate over large datasets. Depending on the size of the dataframe, `itertuples` can be 10x-100x faster than `iterrows`.
🔬 **Measurement:** Timing the execution of `apply_refined_corrections.py` or `generate_overview_table.py` with large input datasets should show a measurable decrease in execution time.

---
*PR created automatically by Jules for task [17217612042466241902](https://jules.google.com/task/17217612042466241902) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->