### PR TITLE
⚡ Bolt: [performance improvement] Optimize rolling MAD calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Pandas iteration optimization
 **Learning:** Iterating over Pandas DataFrames with `iterrows()` is a performance bottleneck due to Series creation overhead.
 **Action:** Replace `iterrows()` with `itertuples(index=False)` and use attribute access for significant speedup without loss of readability.
+
+## 2024-05-18 - Pandas Object Creation in rolling.apply
+**Learning:** Creating pandas objects (like `pd.Series`) inside tightly grouped or rolling loops (e.g. `rolling.apply(lambda x: pd.Series(x)...)`) causes massive overhead due to repeated object instantiations.
+**Action:** Replace pandas operations inside `apply` or `rolling.apply` with pure NumPy equivalents (like `np.nanmedian`) over the provided array `x` to eliminate object creation overhead while preserving logic.

--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -1,6 +1,7 @@
 import os
 from glob import glob
 
+import numpy as np
 from pandas import Series, concat, isna, merge, read_csv, read_excel
 
 RAW_DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
@@ -41,8 +42,10 @@ def find_matching_raw_file(processed_filename):
 def detect_outliers_series(values, window_size=5, threshold=3.0):
     # Simple rolling MAD outlier detection for a pandas Series
     rolling_median = values.rolling(window=window_size, center=True).median()
+    # Optimization: Use pure NumPy instead of creating pd.Series inside the tight rolling loop
+    # This significantly reduces object creation overhead.
     rolling_mad = values.rolling(window=window_size, center=True).apply(
-        lambda x: Series(x).sub(Series(x).median()).abs().median(), raw=True
+        lambda x: np.nanmedian(np.abs(x - np.nanmedian(x))), raw=True
     )
     mad_scale_factor = 1.4826
     rolling_scaled_mad = rolling_mad * mad_scale_factor

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -194,8 +194,10 @@ def detect_outliers(
     rolling_median = values.rolling(window=window_size, center=True).median()
 
     # Calculate rolling MAD
+    # Optimization: Use pure NumPy instead of creating pd.Series inside the tight rolling loop
+    # This significantly reduces object creation overhead.
     rolling_mad = values.rolling(window=window_size, center=True).apply(
-        lambda x: pd.Series(x).sub(pd.Series(x).median()).abs().median(), raw=True
+        lambda x: np.nanmedian(np.abs(x - np.nanmedian(x))), raw=True
     )
 
     mad_scale_factor = 1.4826


### PR DESCRIPTION
💡 **What:** Replaced `pd.Series` instantiation inside the tight loop of `rolling.apply` with pure NumPy equivalents in `scripts/processor.py` and `scripts/export_comparison_sheets.py`.
🎯 **Why:** Creating Pandas objects (like `pd.Series`) repeatedly inside a `rolling.apply` lambda function is extremely slow due to Python object creation overhead. By using `np.nanmedian` and `np.abs` with `raw=True`, the logic stays the same but avoids instantiating a Series on every window step.
📊 **Impact:** Massively reduces the time required to calculate the Modified Z-Score/Median Absolute Deviation (MAD), eliminating a critical execution bottleneck in processing sensor time-series data.
🔬 **Measurement:** Execute `apply_refined_corrections.py` or run `batch_process` to observe a dramatic decrease in script execution time.

_Note: Pre-commit checks passed and syntax was validated using `py_compile` since the full suite could not run locally due to missing mock/pandas dependencies._

---
*PR created automatically by Jules for task [4553280272921602868](https://jules.google.com/task/4553280272921602868) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->