### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,6 +3,9 @@
 
 name: Python Tests
 
+permissions:
+  contents: read
+
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push events but only for the main branch


### PR DESCRIPTION
Potential fix for [https://github.com/abhimehro/series_correction_project_updated/security/code-scanning/1](https://github.com/abhimehro/series_correction_project_updated/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (top-level) so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current behavior for checkout/testing while constraining token power. Place it after `name:` and before `on:` in `.github/workflows/python-tests.yml`. No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
