### PR TITLE
⚡ Bolt: Remove redundant Pandas Series creations

### DIFF
--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -50,7 +50,7 @@ def detect_gaps(
         return []
 
     # Calculate the median time difference
-    median_diff = pd.Series(time_diffs_valid).median()
+    median_diff = time_diffs_valid.median()
 
     if median_diff <= 0:
         log.warning(
@@ -441,8 +441,8 @@ def correct_jumps(
         window_before = result_df[value_col].iloc[jump_idx - window_size : jump_idx]
         window_after = result_df[value_col].iloc[jump_idx : jump_idx + window_size]
 
-        median_before = pd.Series(window_before).median()
-        median_after = pd.Series(window_after).median()
+        median_before = window_before.median()
+        median_after = window_after.median()
 
         if pd.isna(median_before) or pd.isna(median_after):
             log.warning(
@@ -533,9 +533,9 @@ def correct_outliers(
                 continue
             surrounding_values = result_df[value_col].loc[valid_indices_in_window]
             if method == "median":
-                replacement_value = pd.Series(list(surrounding_values)).median()
+                replacement_value = surrounding_values.median()
             else:
-                replacement_value = pd.Series(list(surrounding_values)).mean()
+                replacement_value = surrounding_values.mean()
             if pd.notna(replacement_value):
                 original_value = result_df.loc[outlier_idx, value_col]
                 result_df.loc[outlier_idx, value_col] = replacement_value


### PR DESCRIPTION
💡 **What**:
Removed unnecessary wrapper calls to `pd.Series()` around variables that were already Pandas Series objects in `scripts/processor.py` (e.g., `time_diffs_valid`, `window_before`, `window_after`, `surrounding_values`). Additionally removed unnecessary conversions to `list` prior to re-wrapping. The direct method calls (`.median()`, `.mean()`) are instead invoked directly on the existing Series.

🎯 **Why**:
Wrapping an existing Series in another `pd.Series()` (or converting a Series to a list and back to a Series) is highly inefficient. It allocates redundant memory and performs unnecessary copy operations, representing O(n) overhead that scales with the size of the window/series. 

📊 **Impact**:
Reduces allocation overhead and data copying for statistical aggregations (like median and mean calculations), accelerating the execution of `detect_gaps`, `correct_jumps`, and `correct_outliers`.

🔬 **Measurement**:
The behavior remains identical because `.iloc` and `.loc` natively return Series objects with the required aggregation methods. Syntax verified to be correct via PyCompile since the local test environment lacks Pandas compilation headers.

---
*PR created automatically by Jules for task [9262628527937656597](https://jules.google.com/task/9262628527937656597) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->