### PR TITLE
⚡ Bolt: Remove redundant pd.Series instantiations to reduce allocation overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Pandas Object Creation in rolling.apply
 **Learning:** Creating pandas objects (like `pd.Series`) inside tightly grouped or rolling loops (e.g. `rolling.apply(lambda x: pd.Series(x)...)`) causes massive overhead due to repeated object instantiations.
 **Action:** Pass `raw=True` to `apply`/`rolling.apply` and replace pandas operations with pure NumPy equivalents (like `np.nanmedian`) operating directly on the provided array `x` to eliminate object creation overhead while preserving logic.
+
+## 2024-05-18 - Redundant Pandas Series wrapping
+**Learning:** Wrapping slices returned from `iloc` or `loc` in a `pd.Series()` creates unnecessary overhead, and doing so with `pd.Series(list(slice))` is even worse.
+**Action:** Call aggregate methods like `.median()` or `.mean()` directly on the returned slice (which is already a Series) to reduce object instantiation time.

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -50,7 +50,8 @@ def detect_gaps(
         return []
 
     # Calculate the median time difference
-    median_diff = pd.Series(time_diffs_valid).median()
+    # ⚡ Bolt: Removed redundant pd.Series wrap
+    median_diff = time_diffs_valid.median()
 
     if median_diff <= 0:
         log.warning(
@@ -441,8 +442,9 @@ def correct_jumps(
         window_before = result_df[value_col].iloc[jump_idx - window_size : jump_idx]
         window_after = result_df[value_col].iloc[jump_idx : jump_idx + window_size]
 
-        median_before = pd.Series(window_before).median()
-        median_after = pd.Series(window_after).median()
+        # ⚡ Bolt: Removed redundant pd.Series wraps
+        median_before = window_before.median()
+        median_after = window_after.median()
 
         if pd.isna(median_before) or pd.isna(median_after):
             log.warning(
@@ -532,10 +534,11 @@ def correct_outliers(
                 )
                 continue
             surrounding_values = result_df[value_col].loc[valid_indices_in_window]
+            # ⚡ Bolt: Removed redundant pd.Series(list(...)) wraps
             if method == "median":
-                replacement_value = pd.Series(list(surrounding_values)).median()
+                replacement_value = surrounding_values.median()
             else:
-                replacement_value = pd.Series(list(surrounding_values)).mean()
+                replacement_value = surrounding_values.mean()
             if pd.notna(replacement_value):
                 original_value = result_df.loc[outlier_idx, value_col]
                 result_df.loc[outlier_idx, value_col] = replacement_value


### PR DESCRIPTION
💡 What: Removed unnecessary `pd.Series()` and `pd.Series(list(...))` wrappers around `.iloc` and `.loc` outputs in `scripts/processor.py` before `.median()` and `.mean()` calculations.
🎯 Why: `iloc` and `loc` on a DataFrame column already return a `pd.Series`. Wrapping them in another `pd.Series()` causes unnecessary memory allocation and runtime overhead, especially within loops that process jumps and outliers.
📊 Impact: Eliminates redundant object instantiations in inner correction loops, directly improving performance for jump and outlier correction.
🔬 Measurement: Verify by running tests. The math functions are logically identical, but CPU allocation overhead will be marginally reduced over large datasets.

---
*PR created automatically by Jules for task [5899557146353926983](https://jules.google.com/task/5899557146353926983) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->