### PR TITLE
⚡ Bolt: Redundant Series creation in loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Pandas Object Creation in rolling.apply
 **Learning:** Creating pandas objects (like `pd.Series`) inside tightly grouped or rolling loops (e.g. `rolling.apply(lambda x: pd.Series(x)...)`) causes massive overhead due to repeated object instantiations.
 **Action:** Replace pandas operations inside `apply` or `rolling.apply` with pure NumPy equivalents (like `np.nanmedian`) over the provided array `x` to eliminate object creation overhead while preserving logic.
+
+## 2024-05-18 - Redundant Series Wrapping
+**Learning:** Wrapping objects that are already Pandas Series in `pd.Series()` adds unnecessary overhead from extra allocations and potential data copies.
+**Action:** Call aggregate methods (like `.median()` or `.mean()`) directly on the existing Series or slice rather than re-wrapping it.

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -50,7 +50,7 @@ def detect_gaps(
         return []
 
     # Calculate the median time difference
-    median_diff = pd.Series(time_diffs_valid).median()
+    median_diff = time_diffs_valid.median()
 
     if median_diff <= 0:
         log.warning(
@@ -440,8 +440,8 @@ def correct_jumps(
         window_before = result_df[value_col].iloc[jump_idx - window_size : jump_idx]
         window_after = result_df[value_col].iloc[jump_idx : jump_idx + window_size]
 
-        median_before = pd.Series(window_before).median()
-        median_after = pd.Series(window_after).median()
+        median_before = window_before.median()
+        median_after = window_after.median()
 
         if pd.isna(median_before) or pd.isna(median_after):
             log.warning(
@@ -532,9 +532,9 @@ def correct_outliers(
                 continue
             surrounding_values = result_df[value_col].loc[valid_indices_in_window]
             if method == "median":
-                replacement_value = pd.Series(list(surrounding_values)).median()
+                replacement_value = surrounding_values.median()
             else:
-                replacement_value = pd.Series(list(surrounding_values)).mean()
+                replacement_value = surrounding_values.mean()
             if pd.notna(replacement_value):
                 original_value = result_df.loc[outlier_idx, value_col]
                 result_df.loc[outlier_idx, value_col] = replacement_value


### PR DESCRIPTION
### 💡 **What:**
The optimization removes redundant `pd.Series()` constructors in `scripts/processor.py` that were wrapping objects already recognized as pandas Series. 

### 🎯 **Why:**
Each call to `pd.Series()` on an existing Series object incurs unnecessary overhead due to memory allocation and object validation. By calling aggregate methods like `.median()` and `.mean()` directly on the existing Series or slices, we eliminate these redundant operations. This is particularly beneficial in `correct_jumps` and `correct_outliers` which operate within loops.

### 📊 **Measured Improvement:**
A live benchmark was impractical due to the lack of a functional `pandas` environment in the sandbox. However, this is a standard "zero-cost" optimization that reduces CPU cycles and memory allocations by avoiding unnecessary object creation. In `correct_outliers`, a particularly inefficient `pd.Series(list(surrounding_values))` was replaced with a direct method call, which additionally avoids an expensive conversion to a Python list.

---
*PR created automatically by Jules for task [7461448040340359428](https://jules.google.com/task/7461448040340359428) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->