### PR TITLE
fix(lint): clean ruff findings in scripts

### DIFF
--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -2,7 +2,7 @@ import os
 from glob import glob
 
 import numpy as np
-from pandas import Series, concat, isna, merge, read_csv, read_excel
+from pandas import concat, isna, merge, read_csv, read_excel
 
 RAW_DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
 OUTPUT_DIR = os.path.abspath(
@@ -28,9 +28,6 @@ def find_matching_raw_file(processed_filename):
             return raw_path
     m2 = re.search(r"Year_(\d+) \(Y(\d+)\)_Data", processed_filename)
     if m2:
-        # Store year value explicitly to show it's inspected but not needed
-        # in current implementation (could be used for validation later)
-        year_value = int(m2.group(1))  # Explicit assignment to show intent
         yidx = int(m2.group(2))
         # Try to find S??_Y{yidx:02d}.txt
         for f in os.listdir(RAW_DATA_DIR):

--- a/scripts/fix_output.py
+++ b/scripts/fix_output.py
@@ -3,13 +3,11 @@ import os
 import sys
 
 import pandas as pd
+from scripts.processor import process_data
 
 # Add project root to path
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, PROJECT_ROOT)
-
-# Import your processing functions
-from scripts.processor import process_data
 
 # Set up directories
 DATA_DIR = os.path.join(PROJECT_ROOT, "data")

--- a/scripts/generate_overview_table.py
+++ b/scripts/generate_overview_table.py
@@ -97,7 +97,7 @@ def main(correction_log_path, updated_averages_csv_path):
         # Warn if any year pairs could not be parsed
         if unmatched_year_pairs:
             print(
-                f"\nWARNING: The following Year_Pair_Outlier strings could not be parsed and were skipped:"
+                "\nWARNING: The following Year_Pair_Outlier strings could not be parsed and were skipped:"
             )
             for s in unmatched_year_pairs:
                 print(f"  - {s}")

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -596,10 +596,12 @@ def process_data(
     time_col = merged_config["time_col"]
     if time_col not in processed_data.columns:
         log.warning(
-            "Time column '{time_col}' not found in data columns: {list(processed_data.columns)}"
+            "Time column '%s' not found in data columns: %s",
+            time_col,
+            list(processed_data.columns),
         )
         raise ValueError(
-            "Time column '{time_col}' not found in data columns: {list(processed_data.columns)}"
+            f"Time column '{time_col}' not found in data columns: {list(processed_data.columns)}"
         )
 
     if not pd.api.types.is_numeric_dtype(processed_data[time_col]):
@@ -632,10 +634,10 @@ def process_data(
         log.info("Auto-detected value column: '%s'", value_col)
     elif value_col not in processed_data.columns:
         raise ValueError(
-            "Specified value column '{value_col}' not found in data columns: {list(processed_data.columns)}"
+            f"Specified value column '{value_col}' not found in data columns: {list(processed_data.columns)}"
         )
     elif not pd.api.types.is_numeric_dtype(processed_data[value_col]):
-        raise ValueError("Specified value column '{value_col}' is not numeric.")
+        raise ValueError(f"Specified value column '{value_col}' is not numeric.")
 
     window_size = merged_config["window_size"]
     threshold = merged_config["threshold"]

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -611,10 +611,10 @@ def process_data(
             log.info(
                 "Converted time column '%s' to numeric (Unix timestamp).", time_col
             )
-        except Exception as e:
+        except Exception as exc:
             raise ValueError(
-                "Time column '{time_col}' is not numeric and could not be converted: {e}"
-            )
+                f"Time column '{time_col}' is not numeric and could not be converted: {exc}"
+            ) from exc
     value_col = merged_config["value_col"]
     if value_col is None:
         numeric_cols = processed_data.select_dtypes(include=np.number).columns

--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -601,7 +601,7 @@ def test_batch_process_process_error(
     """Test handling of error during data processing."""
     # Arrange
     series = 26  # type: int
-    years = (1995, 1995)  # type: Tuple[int, int]
+    years = (1995, 1995)
 
     mock_dependencies.update(
         {

--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -4,7 +4,7 @@ Unit tests for the batch_correction module.
 """
 
 import os
-from typing import Dict, Tuple
+from typing import Dict
 
 import mock
 import pandas as pd  # type: ignore


### PR DESCRIPTION
## Summary
Clean up high-confidence Ruff findings across scripts without changing the correction algorithms: remove unused imports/assignments, move a module import to the top of the file, remove an unnecessary f-string, and preserve exception context when timestamp conversion fails.

## Review & Testing Checklist for Human
- [ ] Review `scripts/processor.py` to confirm the improved conversion error remains acceptable for user-facing CLI output.
- [ ] If desired, run a representative `seatek-correction --dry-run` against local sample data to confirm no behavior changes in batch processing.
- [ ] Note that the full `scripts/tests/test_batch_correction.py` suite still has pre-existing batch-correction expectation failures; focused non-batch CLI/refined-correction tests pass.

### Notes
Verified with:
- `PYENV_VERSION=3.10.16 python setup.py --name`
- `PYENV_VERSION=3.10.16 python -m py_compile scripts/*.py`
- `PYENV_VERSION=3.10.16 python -m ruff check scripts`
- `PYENV_VERSION=3.10.16 python -m black --check scripts`
- `PYENV_VERSION=3.10.16 python -m pytest scripts/tests/test_apply_refined_corrections.py scripts/tests/test_series_correction_cli.py -v`

Full `PYENV_VERSION=3.10.16 python -m pytest scripts/tests -v` was also run and still fails in pre-existing `test_batch_correction.py` cases unrelated to these lint-only changes.

Link to Devin session: https://app.devin.ai/sessions/2f6682137176411a89d01e9465519071
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->