### PR TITLE
Daily QA: fix test mock import for Python 3 stdlib

### DIFF
--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -5,8 +5,8 @@ Unit tests for the batch_correction module.
 
 import os
 from typing import Dict
+from unittest import mock
 
-import mock
 import pandas as pd  # type: ignore
 import pytest
 from _pytest.logging import LogCaptureFixture

--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -168,7 +168,7 @@ def mock_processor_mod(mocker):
 def test_batch_process_happy_path_all_series_with_config(mock_dependencies):
     import importlib
 
-    from mock import MagicMock, patch
+    from unittest.mock import MagicMock, patch
 
     def isfile_side_effect(path):
         if os.path.basename(path) == "river_mile_map.csv":
@@ -294,7 +294,7 @@ def test_batch_process_happy_path_all_series_with_config(mock_dependencies):
 def test_batch_process_happy_path_specific_series_no_config(mock_dependencies):
     import importlib
 
-    from mock import MagicMock, patch
+    from unittest.mock import MagicMock, patch
 
     def isfile_side_effect(path):
         fname = os.path.basename(path)


### PR DESCRIPTION
## Summary
Automated daily QA found `scripts/tests/test_batch_correction.py` importing the third-party `mock` package, which is not installed in minimal CI/agent environments and causes **pytest collection** to fail with `ModuleNotFoundError: No module named 'mock'`.

## Change
- Replace `import mock` with `from unittest import mock` (stdlib, Python 3).

## Verification
```bash
export PATH="$HOME/.local/bin:$PATH"
cd series_correction_project_updated
python3 -m pytest scripts/tests/test_batch_correction.py -q --tb=line
```
Collection succeeds; some tests in this file still error/fail due to fixture/data expectations (pre-existing); this change removes the import-time failure.

## Security
No runtime behavior change; test-only import path.

---
*Daily QA & Agentic Review — 2026-05-16*