### PR TITLE
fix(lint): remove unused imports flagged by ruff F401

### DIFF
--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -8,7 +8,7 @@ in Seatek sensor time-series data based on the audit report suggestions.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd

--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -10,7 +10,6 @@ from typing import Dict
 from unittest import mock
 import pandas as pd  # type: ignore
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 # Module to test (adjust path if your structure differs)
 # Assuming tests run from the project root


### PR DESCRIPTION
## Summary
Remove 4 unused imports detected by `ruff check scripts`:
- `typing.Dict`, `typing.List`, `typing.Optional` in `scripts/processor.py`
- `_pytest.logging.LogCaptureFixture` in `scripts/tests/test_batch_correction.py`

All 4 violations are auto-fixable F401 (imported but unused).

## Review & Testing Checklist for Human
- [ ] Verify `PYENV_VERSION=3.10.16 python -m pytest scripts/tests -v` passes (29 tests)
- [ ] Verify `PYENV_VERSION=3.10.16 python -m ruff check scripts` reports no errors

### Notes
- Identified during Jules Daily QA & Agentic Review (2026-05-19)
- Tests confirmed passing after fix (29 passed)

Link to Devin session: https://app.devin.ai/sessions/bf72bdef1e9243f28091d81269dcd68d
Requested by: @abhimehro