### PR TITLE
chore: remove unused imports (ruff F401)

### DIFF
--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -8,7 +8,7 @@ in Seatek sensor time-series data based on the audit report suggestions.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd

--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -10,7 +10,6 @@ from typing import Dict
 from unittest import mock
 import pandas as pd  # type: ignore
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 # Module to test (adjust path if your structure differs)
 # Assuming tests run from the project root


### PR DESCRIPTION
## Summary
Remove 4 unused imports flagged by `ruff check scripts` (F401):
- `scripts/processor.py`: Remove `Dict`, `List`, `Optional` from `typing` import (only `Any` is used; the others appeared only in docstrings, not type annotations)
- `scripts/tests/test_batch_correction.py`: Remove unused `LogCaptureFixture` import from `_pytest.logging`

All 29 tests pass. Ruff now reports **All checks passed!**

## Review & Testing Checklist for Human
- [ ] Verify `ruff check scripts` passes cleanly
- [ ] Verify `pytest scripts/tests/ -v` still passes (29/29)

### Notes
Identified during Jules Daily QA & Agentic Review.


Link to Devin session: https://app.devin.ai/sessions/cf0577786ca54f1583c90b5baf0b0d6c
Requested by: @abhimehro