### PR TITLE
🧹 Remove dead code: load_series_data

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,6 @@
+========== ELIR ==========
+PURPOSE: Removed unused `load_series_data` function and `pandas` import from `scripts/loaders.py`.
+SECURITY: Reduces attack surface slightly by removing unused imports, though primarily a code hygiene task.
+FAILS IF: N/A - Function was entirely dead code.
+VERIFY: Confirm the CI pipeline passes.
+MAINTAIN: Avoid adding one-off loader functions without ensuring they are integrated into the main application execution path.

--- a/scripts/loaders.py
+++ b/scripts/loaders.py
@@ -1,16 +1,6 @@
 import json
 
-import pandas as pd
-
 
 def load_config(config_path="scripts/config.json"):
     with open(config_path, "r") as f:
         return json.load(f)
-
-
-def load_series_data(series_id, config):
-    series_cfg = config["series"].get(str(series_id))
-    if series_cfg:
-        df = pd.read_csv(series_cfg["diagnostic"])
-        return df
-    raise ValueError("Series {series_id} not defined in config.")

--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -458,9 +458,7 @@ def test_batch_process_data_dir_not_found(mock_dependencies):
 
     # Act & Assert
     expected_data_dir_inner = os.path.join(os.getcwd(), "data")  # Default dir check
-    with pytest.raises(
-        FileNotFoundError, match=r"Default data directory not found"
-    ):
+    with pytest.raises(FileNotFoundError, match=r"Default data directory not found"):
         batch_process(series_selection, river_miles, years, dry_run)
     # Ensure isdir was called for the default path
     # Accept both possible calls for isdir: data_dir and data_dir/output


### PR DESCRIPTION
## 🎯 What
Removed the unused `load_series_data` function and its unused `pandas` import from `scripts/loaders.py`. 

## 💡 Why
Codebase searches confirm that `load_series_data` is dead code and never called. Removing dead code reduces maintenance overhead, improves readability, and satisfies code health checks without altering behavior.

## ✅ Verification
- Conducted codebase search (`grep -rn "load_series_data" .`) confirming 0 usages.
- Formatted and linted changes (`black` and `flake8`).
- Ran full test suite (`pytest scripts/tests/ -v`). All tests pass (29/29).

## ✨ Result
`scripts/loaders.py` is cleaner, shorter, and only contains actively used functions (`load_config`).

---
*PR created automatically by Jules for task [15261467362398883175](https://jules.google.com/task/15261467362398883175) started by @abhimehro*