### PR TITLE
Fix path traversal vulnerability in load_config and missing f-string

### DIFF
--- a/scripts/loaders.py
+++ b/scripts/loaders.py
@@ -1,16 +1,15 @@
 import json
-
 import pandas as pd
 
-
 def load_config(config_path="scripts/config.json"):
+    if ".." in config_path:
+        raise ValueError("Path traversal detected")
     with open(config_path, "r") as f:
         return json.load(f)
-
 
 def load_series_data(series_id, config):
     series_cfg = config["series"].get(str(series_id))
     if series_cfg:
         df = pd.read_csv(series_cfg["diagnostic"])
         return df
-    raise ValueError("Series {series_id} not defined in config.")
+    raise ValueError(f"Series {series_id} not defined in config.")

--- a/seatek_series_correction.egg-info/SOURCES.txt
+++ b/seatek_series_correction.egg-info/SOURCES.txt
@@ -1,5 +1,6 @@
 LICENSE
 README.md
+setup.cfg
 setup.py
 scripts/__init__.py
 scripts/apply_refined_corrections.py
@@ -13,6 +14,7 @@ scripts/manual_batch_run.py
 scripts/processor.py
 scripts/run_analysis.py
 scripts/series_correction_cli.py
+scripts/spreadsheet_safety.py
 seatek_series_correction.egg-info/PKG-INFO
 seatek_series_correction.egg-info/SOURCES.txt
 seatek_series_correction.egg-info/dependency_links.txt


### PR DESCRIPTION
- Added a check for `..` in `config_path` in `scripts/loaders.py`'s `load_config` to prevent path traversal and make `test_load_config_path_traversal` pass.
- Fixed a missing `f` prefix on an f-string in `load_series_data`.

---
*PR created automatically by Jules for task [7170311916730585736](https://jules.google.com/task/7170311916730585736) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->