### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal bypass in config loader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Attempting to hide exception details by simply removing `from exc` fails due to Python 3's implicit exception chaining.
 **Learning:** In Python 3, exceptions raised inside an `except` block implicitly chain the previous exception to `__context__`, leaking the original stack trace unless explicitly overridden.
 **Prevention:** Always use `raise CustomException(...) from None` to fully suppress the original exception's context and prevent internal detail leakage to end-users.
+## 2025-02-24 - Path Traversal Bypass
+**Vulnerability:** A symlink path traversal bypass in `scripts/loaders.py` caused by using `os.path.abspath` instead of `os.path.realpath`.
+**Learning:** `os.path.abspath` standardizes path representation but does not resolve symbolic links, allowing an attacker to bypass `os.path.commonpath` checks if they control symlinks within the allowed directory.
+**Prevention:** Always use `os.path.realpath` to fully resolve symlinks before verifying directory confinement using `os.path.commonpath`.

--- a/scripts/loaders.py
+++ b/scripts/loaders.py
@@ -4,8 +4,8 @@ import os
 
 def load_config(config_path="scripts/config.json"):
     # SECURITY: reject paths that escape the working directory (CWE-22).
-    base_dir = os.path.abspath(os.getcwd())
-    resolved = os.path.abspath(config_path)
+    base_dir = os.path.realpath(os.getcwd())
+    resolved = os.path.realpath(config_path)
     try:
         if os.path.commonpath([base_dir, resolved]) != base_dir:
             raise ValueError("Path traversal detected")


### PR DESCRIPTION
- **🚨 Severity:** HIGH
- **💡 Vulnerability:** The `load_config` function relied on `os.path.abspath` to sanitize the base directory and requested file path before validating confinement using `os.path.commonpath`. Because `abspath` does not resolve symlinks, an attacker who could introduce a symlink pointing outside the working directory could trick `commonpath` into passing the check.
- **🎯 Impact:** Path Traversal - Could allow an attacker to read arbitrary files from the filesystem using symbolic links.
- **🔧 Fix:** Changed `os.path.abspath` to `os.path.realpath` to ensure symbolic links are fully resolved prior to the confinement check.
- **✅ Verification:** Code linting and test suite ran successfully with no regressions. Code review marked as correct.

---
*PR created automatically by Jules for task [17225252658138253866](https://jules.google.com/task/17225252658138253866) started by @abhimehro*