### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CSV/Formula Injection in Categorical Columns

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** A symlink path traversal bypass in `scripts/loaders.py` caused by using `os.path.abspath` instead of `os.path.realpath`.
 **Learning:** `os.path.abspath` standardizes path representation but does not resolve symbolic links, allowing an attacker to bypass `os.path.commonpath` checks if they control symlinks within the allowed directory.
 **Prevention:** Always use `os.path.realpath` to fully resolve symlinks before verifying directory confinement using `os.path.commonpath`.
+## 2025-02-25 - Pandas Categorical Type CSV/Formula Injection
+**Vulnerability:** Malicious formulas were not escaped in Pandas `category` columns during spreadsheet sanitization.
+**Learning:** `dataframe.select_dtypes(include=["object", "string"])` misses `category` types. A standard `.map()` on a category column throws an error or silently fails; one must use `.cat.rename_categories()` to safely escape categorical values without breaking their properties.
+**Prevention:** Always include `category` in `select_dtypes` for sanitization, and handle `CategoricalDtype` uniquely using its built-in `.cat` accessor methods.

--- a/scripts/spreadsheet_safety.py
+++ b/scripts/spreadsheet_safety.py
@@ -16,13 +16,17 @@ def escape_spreadsheet_formula(value: Any) -> Any:
 
 
 def sanitize_dataframe_for_spreadsheet(dataframe: pd.DataFrame) -> pd.DataFrame:
-    object_columns = dataframe.select_dtypes(include=["object", "string"]).columns
+    object_columns = dataframe.select_dtypes(include=["object", "string", "category"]).columns
     if object_columns.empty:
         return dataframe
 
     sanitized = dataframe.copy()
     for column in object_columns:
-        sanitized[column] = sanitized[column].map(escape_spreadsheet_formula)
+        if isinstance(sanitized[column].dtype, pd.CategoricalDtype):
+            new_categories = [escape_spreadsheet_formula(cat) for cat in sanitized[column].cat.categories]
+            sanitized[column] = sanitized[column].cat.rename_categories(new_categories)
+        else:
+            sanitized[column] = sanitized[column].map(escape_spreadsheet_formula)
     return sanitized
 
 

--- a/scripts/tests/test_spreadsheet_safety.py
+++ b/scripts/tests/test_spreadsheet_safety.py
@@ -87,3 +87,12 @@ def test_batch_process_escapes_formula_like_raw_cells(tmp_path, monkeypatch):
     cell = workbook.active["C2"]
     assert cell.value == "'" + payload
     assert cell.data_type == "s"
+
+def test_sanitize_dataframe_escapes_category_columns():
+    import pandas as pd
+
+    dataframe = pd.DataFrame({"value": pd.Categorical(["=1+2", "safe"])})
+    sanitized = sanitize_dataframe_for_spreadsheet(dataframe)
+    assert sanitized["value"].iloc[0] == "'=1+2"
+    assert sanitized["value"].iloc[1] == "safe"
+    assert isinstance(sanitized["value"].dtype, pd.CategoricalDtype)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Pandas `category` columns containing formula injection payloads were previously missed during spreadsheet export sanitization, as the existing sanitization only covered `object` and `string` types.
🎯 **Impact**: If user data contained malicious CSV/Formula injection payloads mapped to a Pandas `category` column, the payload would be exported directly to the spreadsheet. If a user subsequently opened the exported spreadsheet, the malicious payload could execute arbitrary commands or lead to data exfiltration.
🔧 **Fix**: Extended `sanitize_dataframe_for_spreadsheet` in `scripts/spreadsheet_safety.py` to explicitly select `category` columns. Handled `pd.CategoricalDtype` by escaping its values using `.cat.rename_categories()` to preserve the column's underlying category constraints safely.
✅ **Verification**: Implemented a new unit test, `test_sanitize_dataframe_escapes_category_columns`, in `scripts/tests/test_spreadsheet_safety.py` that verifies formulas are successfully prepended with an apostrophe and that the column remains a `category` type.

---
*PR created automatically by Jules for task [13535221484582273645](https://jules.google.com/task/13535221484582273645) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->