### PR TITLE
🧹 Fix flake8 blank line formatting in test_spreadsheet_safety.py

### DIFF
--- a/scripts/tests/test_spreadsheet_safety.py
+++ b/scripts/tests/test_spreadsheet_safety.py
@@ -88,6 +88,7 @@ def test_batch_process_escapes_formula_like_raw_cells(tmp_path, monkeypatch):
     assert cell.value == "'" + payload
     assert cell.data_type == "s"
 
+
 def test_sanitize_dataframe_escapes_category_columns():
     import pandas as pd
 


### PR DESCRIPTION
🎯 What: Inserted a required blank line at line 91 in `scripts/tests/test_spreadsheet_safety.py` to satisfy PEP-8 standards.
💡 Why: The `flake8` linter was reporting an `E302 expected 2 blank lines, found 1` error.
✅ Verification: Ran `flake8 scripts/ --max-line-length=150` and verified the error was resolved. Ran `python3 -m pytest scripts/tests/ -v` to ensure no tests were broken.
✨ Result: The repository is now 100% clean passing all local linters and tests.

---
*PR created automatically by Jules for task [8054704411560033636](https://jules.google.com/task/8054704411560033636) started by @abhimehro*