### PR TITLE
feat(copilot): Parse multiple workspace roots if Copilot supports it

### DIFF
--- a/.github/github-copilot-1password-hooks-bundle/adapters/github-copilot.sh
+++ b/.github/github-copilot-1password-hooks-bundle/adapters/github-copilot.sh
@@ -19,14 +19,17 @@ source "${_ADAPTER_DIR}/_lib.sh"
 normalize_input() {
     local raw_payload="$1"
 
-    local cwd tool_name command workspace_roots_json
+    local cwd tool_name command workspace_roots workspace_roots_json
     cwd=$(extract_json_string "$raw_payload" "cwd")
     tool_name=$(extract_json_string "$raw_payload" "tool_name")
     command=$(extract_json_string "$raw_payload" "command")
 
-    # Copilot currently provides cwd as the single workspace root.
-    # TODO: If Copilot adds multi-root workspace support, parse roots from the payload instead.
-    workspace_roots_json=$(paths_to_json_array "$cwd")
+    # Try workspace_roots array first if Copilot supports it, fall back to cwd
+    workspace_roots=$(parse_json_workspace_roots "$raw_payload")
+    if [[ -z "$workspace_roots" ]] && [[ -n "$cwd" ]]; then
+        workspace_roots="$cwd"
+    fi
+    workspace_roots_json=$(paths_to_json_array "$workspace_roots")
 
     build_canonical_input \
         "github-copilot" \


### PR DESCRIPTION
🎯 What
Parse multiple workspace roots from the Copilot payload if the multi-root workspace support is added, falling back to cwd if not found.

💡 Why
Currently, Copilot only provides `cwd` as the single workspace root. This prepares the hooks for when Copilot adds support for parsing multiple roots from the payload.

✅ Verification
Tested locally with mock JSON inputs containing multiple `workspace_roots` to confirm correct extraction and fallback to `cwd` if empty. Passed `python3 -m pytest` and `flake8`.

========== ELIR ==========
PURPOSE: Update `normalize_input` to correctly extract multiple workspace roots from Copilot payloads if supported, returning an array or falling back to `cwd`.
SECURITY: Uses safe custom JSON parsing functions without external dependencies.
FAILS IF: Payload structure dramatically changes beyond expected patterns.
VERIFY: Array creation and handling for both multi-root and single-root (cwd) outputs.
MAINTAIN: Copilot payloads may eventually populate `workspace_roots` inherently.

---
*PR created automatically by Jules for task [11605265912502138394](https://jules.google.com/task/11605265912502138394) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/series_correction_project_updated/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->