### PR TITLE
docs: correct stale test-failure note in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ CLI tool to detect and correct discontinuities (jumps, gaps, outliers) in Seatek
 
 - **`pandas<2.0` constraint is incompatible with Python 3.12**: The pinned `pandas<2.0` in `scripts/requirements.txt` cannot build from source on Python 3.12+. Install dependencies individually (without the upper bound) then install the package with `pip3 install --user --no-deps -e .`.
 - **`mock` module required**: `test_batch_correction.py` imports `mock` (not `unittest.mock`). Install with `pip3 install --user mock`.
-- **Pre-existing test failures**: 9 tests in `test_batch_correction.py` fail due to `pandas` API changes (`errors="ignore"` removed in pandas 2.x). These are not environment issues.
+- **Test status**: With the documented dependency install (which resolves to a current pandas, e.g. 3.x), the full suite passes — `python3 -m pytest scripts/tests/ -v` reports `33 passed`, including `test_batch_correction.py`. (An older note here claimed 9 `test_batch_correction.py` failures under pinned pandas 2.x; that no longer applies with the unpinned install above.)
 - **Test path**: Tests are under `scripts/tests/`, not `tests/`.
 - **Data files**: `.txt` sensor data files in `data/` are committed for Series 26 and 27. Output goes to `data/output/`.
 - Use `python3` (not `python`) as the command.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `## Cursor Cloud specific instructions` test note in `AGENTS.md`. The previous note claimed "9 tests in `test_batch_correction.py` fail due to pandas API changes (`errors='ignore'` removed in pandas 2.x)". With the documented dependency install (no pandas upper bound, which resolves to current pandas — 3.0.3 in the cloud VM), the full suite passes.

## Verification

- Installed deps per AGENTS.md (`pandas>=2.0` resolved to 3.0.3) + `mock`, then `pip3 install --user --no-deps -e .`.
- ✅ `python3 -m pytest scripts/tests/ -v` → `33 passed`, with `test_batch_correction.py` collected and passing.
- ✅ `seatek-correction --series 26 --river-miles 54.0 53.0 --years 1995 1996 --dry-run` ran the correction pipeline end-to-end on committed Series 26 data.

Docs-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-305f427e-4e89-4172-be3b-5ee784753861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-305f427e-4e89-4172-be3b-5ee784753861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

