### PR TITLE
🧪 [testing improvement] Add missing error path test for process_data

### DIFF
--- a/scripts/tests/test_processor.py
+++ b/scripts/tests/test_processor.py
@@ -1,0 +1,22 @@
+import logging
+import pytest
+import pandas as pd
+from scripts.processor import process_data
+
+
+def test_process_data_time_col_parsing_failure(caplog):
+    """Test that process_data correctly raises ValueError and logs an exception when time_col parsing fails."""
+    df = pd.DataFrame(
+        {"Time (Seconds)": ["not_a_time", "also_not_a_time"], "Value": [1.0, 2.0]}
+    )
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(
+            ValueError, match="Time column is not numeric and could not be converted"
+        ):
+            process_data(df)
+
+    assert (
+        "Time column 'Time (Seconds)' is not numeric and could not be converted"
+        in caplog.text
+    )

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,6 @@
+[x] Identify the code causing the bug and determine the best approach.
+[x] Write the missing test.
+[x] Format with black.
+[x] Lint with flake8.
+[x] Run the full test suite with pytest.
+[x] Send summary back to the user.

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,0 @@
-[x] Identify the code causing the bug and determine the best approach.
-[x] Write the missing test.
-[x] Format with black.
-[x] Lint with flake8.
-[x] Run the full test suite with pytest.
-[x] Send summary back to the user.


### PR DESCRIPTION
🎯 **What:** The `process_data` function in `scripts/processor.py` lacked a test covering its error path when the configured time column consists of non-numeric, non-datetime strings. This commit introduces `scripts/tests/test_processor.py` with `test_process_data_time_col_parsing_failure` to close this testing gap.

📊 **Coverage:** The test explicitly verifies that when passing an unparseable time column, `process_data` captures the conversion failure, logs an error exception, and raises a standard `ValueError`.

✨ **Result:** A new dedicated test file covering a failure mode for `process_data`, improving robustness.

========== ELIR ==========
PURPOSE: The new test checks the `ValueError` and exception log on unparseable time columns in `process_data`.
SECURITY: Mitigates silent failure points by ensuring that data frames failing timestamp conversion error out correctly.
FAILS IF: Time columns containing invalid strings are somehow successfully coerced or silently bypassed instead of throwing the expected ValueError.
VERIFY: The full test suite runs at 100% and correctly asserts both the error and matching caplog text.
MAINTAIN: Keep this up-to-date with any changes in the underlying datetime parsing error messages or logging outputs in `scripts/processor.py`.

---
*PR created automatically by Jules for task [18028126391646505888](https://jules.google.com/task/18028126391646505888) started by @abhimehro*