### PR TITLE
test(processor): add missing error path test for process_data (salvages #109)

### DIFF
--- a/scripts/tests/test_processor.py
+++ b/scripts/tests/test_processor.py
@@ -1,7 +1,9 @@
+import logging
+import pytest
 import pandas as pd
 import numpy as np
 
-from scripts.processor import detect_outliers
+from scripts.processor import detect_outliers, process_data
 
 
 def test_detect_outliers_basic():
@@ -56,3 +58,25 @@ def test_detect_outliers_zero_mad():
     # window_size=5, outlier at index 3 (100.0)
     outliers = detect_outliers(data, value_col="value", window_size=5, threshold=3.0)
     assert outliers == [3]
+
+import logging
+import pytest
+from scripts.processor import process_data
+
+
+def test_process_data_time_col_parsing_failure(caplog):
+    """Test that process_data correctly raises ValueError and logs an exception when time_col parsing fails."""
+    df = pd.DataFrame(
+        {"Time (Seconds)": ["not_a_time", "also_not_a_time"], "Value": [1.0, 2.0]}
+    )
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(
+            ValueError, match="Time column is not numeric and could not be converted"
+        ):
+            process_data(df)
+
+    assert (
+        "Time column 'Time (Seconds)' is not numeric and could not be converted"
+        in caplog.text
+    )


### PR DESCRIPTION
## Salvage PR (Phase 2)

**Supersedes:** #109 (CONFLICTING/DIRTY)

### Purpose
Rebuilds the valuable test addition from #109 onto fresh `main`, avoiding merge conflicts from stale branch state.

### Verification
```bash
python3 -m pytest scripts/tests/test_processor.py -q
```

### ELIR
- **Purpose:** Adds error-path coverage for `process_data` that was blocked behind conflicts on #109.
- **Security:** Test-only change; no production logic modified.
- **Fails if:** `process_data` error handling API changed on `main` without updating the test.
- **Verify:** Run pytest command above; confirm new test exercises the intended error branch.
- **Maintain:** Rebuild from `main` if processor signatures change — do not use `update-branch` on the original #109 branch.