### PR TITLE
Jules Daily QA & Agentic Review: Fix pandas to_datetime format warning

### DIFF
--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -647,7 +647,7 @@ def process_data(
 
     if not pd.api.types.is_numeric_dtype(processed_data[time_col]):
         try:
-            processed_data[time_col] = pd.to_datetime(processed_data[time_col])
+            processed_data[time_col] = pd.to_datetime(processed_data[time_col], format='mixed')
             processed_data[time_col] = (
                 processed_data[time_col] - pd.Timestamp("1970-01-01")
             ) // pd.Timedelta("1s")


### PR DESCRIPTION
This PR fixes a `UserWarning` from `pd.to_datetime` by specifying `format='mixed'` explicitly in `scripts/processor.py` (line 650) to suppress inference warnings in Pandas 2.0+.

---
*PR created automatically by Jules for task [12239377508000197816](https://jules.google.com/task/12239377508000197816) started by @abhimehro*