### PR TITLE
Agentic QA: Minor linting and code quality fixes

### DIFF
--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -135,7 +135,7 @@ def export_comparisons():
                 if cols:
                     cols[0] = "Time (Seconds)"
                 raw_df.columns = cols
-        except (IOError, ValueError, FileNotFoundError) as e:
+        except (IOError, ValueError) as e:
             print(f"[WARN] Could not load raw file {raw_file}: {e}")
             continue
         except Exception as e:
@@ -145,7 +145,7 @@ def export_comparisons():
             continue
         try:
             proc_df = read_excel(proc_file)
-        except (IOError, ValueError, FileNotFoundError) as e:
+        except (IOError, ValueError) as e:
             print(f"[WARN] Could not load processed file {proc_file}: {e}")
             continue
         except Exception as e:

--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -264,7 +264,7 @@ def test_batch_process_happy_path_all_series_with_config(mock_dependencies):
         assert all(status in valid_statuses for status in summary_df["Status"].tolist())
         assert (summary_df["Records"] == 5).all()
         # Output assertions
-        for year, yi, series in [
+        for year, yi, _series in [
             (1995, "Y01", 26),
             (1996, "Y02", 26),
             (1995, "Y01", 27),


### PR DESCRIPTION
Automated Daily QA findings:
- Removed redundant `FileNotFoundError` from an `except` block that also catches `IOError`
- Prefixed unused loop variable `series` with `_series` in tests to resolve a linting warning

These are safe, minor code quality improvements.

---
*PR created automatically by Jules for task [10182892520083958350](https://jules.google.com/task/10182892520083958350) started by @abhimehro*