### PR TITLE
🧹 Remove unnecessary global variables in export_comparison_sheets.py

### DIFF
--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -189,10 +189,5 @@ def export_comparisons():
         print(f"[INFO] Exported comparison: {out_path}")
 
 
-# Initialize these variables at module level to avoid undefined variable warnings
-# They will be properly set during execution
-raw_df = None
-processed_df = None
-
 if __name__ == "__main__":
     export_comparisons()


### PR DESCRIPTION
🎯 **What:** Removed unnecessary module-level variable declarations (`raw_df = None`, `processed_df = None`) at the bottom of `scripts/export_comparison_sheets.py`.

💡 **Why:** Python handles variable scope dynamically during runtime, making these trailing module-level definitions both unnecessary and potentially misleading. Removing them cleans up dead code from the module, improving maintainability and reducing visual clutter just before the standard `__main__` execution block.

✅ **Verification:** Verified safety by running the full test suite (`pytest`) to confirm zero breakages, and ran `flake8` and `black` to ensure the codebase remains clean and well-formatted. All checks passed successfully.

✨ **Result:** Improved module code health and removed extraneous variable declarations without impacting functionality.

---
*PR created automatically by Jules for task [4836501847663115995](https://jules.google.com/task/4836501847663115995) started by @abhimehro*