### PR TITLE
🧪 Add unit tests for correct_outliers functionality

### DIFF
--- a/scripts/tests/test_processor.py
+++ b/scripts/tests/test_processor.py
@@ -79,59 +79,37 @@ def test_correct_outliers_empty_indices():
     pd.testing.assert_frame_equal(result, data)
 
 
-def test_correct_outliers_remove():
-    """Test removing outliers (replaced with NaN)."""
-    data = pd.DataFrame({"value": [1.0, 100.0, 3.0]})
+@pytest.mark.parametrize(
+    "method, window_size, data_vals, outlier_indices, expected_val, check_nan",
+    [
+        ("remove", 3, [1.0, 100.0, 3.0], [1], None, True),
+        ("interpolate", 3, [1.0, 100.0, 3.0], [1], 2.0, False),
+        ("median", 3, [1.0, 2.0, 100.0, 4.0, 5.0], [2], 3.0, False),
+        ("median", 5, [1.0, 2.0, 100.0, 4.0, 5.0], [2], 3.0, False),
+        ("mean", 3, [1.0, 2.0, 100.0, 4.0, 5.0], [2], 3.0, False),
+        ("mean", 3, [1.0, 2.0, 100.0, 10.0, 5.0], [2], 6.0, False),
+    ],
+)
+def test_correct_outliers_methods(
+    method, window_size, data_vals, outlier_indices, expected_val, check_nan
+):
+    """Test correcting outliers using various methods."""
+    data = pd.DataFrame({"value": data_vals})
     result = correct_outliers(
-        data, outlier_indices=[1], value_col="value", method="remove"
+        data,
+        outlier_indices=outlier_indices,
+        value_col="value",
+        window_size=window_size,
+        method=method,
     )
-    assert pd.isna(result.loc[1, "value"])
-    assert result.loc[0, "value"] == 1.0
-    assert result.loc[2, "value"] == 3.0
 
+    idx = outlier_indices[0]
+    if check_nan:
+        assert pd.isna(result.loc[idx, "value"])
+    else:
+        assert result.loc[idx, "value"] == expected_val
 
-def test_correct_outliers_interpolate():
-    """Test interpolating outliers."""
-    data = pd.DataFrame({"value": [1.0, 100.0, 3.0]})
-    result = correct_outliers(
-        data, outlier_indices=[1], value_col="value", method="interpolate"
-    )
-    assert result.loc[1, "value"] == 2.0  # (1.0 + 3.0) / 2
-    assert result.loc[0, "value"] == 1.0
-    assert result.loc[2, "value"] == 3.0
-
-
-def test_correct_outliers_median():
-    """Test replacing outliers with the median of the window."""
-    # window_size = 3 (padding = 1 on each side)
-    # Outlier at index 2 (100.0). Window is [2.0, NaN, 4.0] -> Median 3.0
-    data = pd.DataFrame({"value": [1.0, 2.0, 100.0, 4.0, 5.0]})
-    result = correct_outliers(
-        data, outlier_indices=[2], value_col="value", window_size=3, method="median"
-    )
-    assert result.loc[2, "value"] == 3.0
-
-    # window_size = 5 (padding = 2 on each side)
-    # Window is [1.0, 2.0, NaN, 4.0, 5.0] -> Median 3.0
-    result2 = correct_outliers(
-        data, outlier_indices=[2], value_col="value", window_size=5, method="median"
-    )
-    assert result2.loc[2, "value"] == 3.0
-
-
-def test_correct_outliers_mean():
-    """Test replacing outliers with the mean of the window."""
-    # window_size = 3 (padding = 1 on each side)
-    # Outlier at index 2. Window is [2.0, NaN, 4.0] -> Mean 3.0
-    data = pd.DataFrame({"value": [1.0, 2.0, 100.0, 4.0, 5.0]})
-    result = correct_outliers(
-        data, outlier_indices=[2], value_col="value", window_size=3, method="mean"
-    )
-    assert result.loc[2, "value"] == 3.0
-
-    # window_size = 3. Window [2.0, NaN, 10.0] -> Mean 6.0
-    data2 = pd.DataFrame({"value": [1.0, 2.0, 100.0, 10.0, 5.0]})
-    result3 = correct_outliers(
-        data2, outlier_indices=[2], value_col="value", window_size=3, method="mean"
-    )
-    assert result3.loc[2, "value"] == 6.0
+    # Verify that non-outlier values are unchanged
+    for i, original_val in enumerate(data_vals):
+        if i not in outlier_indices:
+            assert result.loc[i, "value"] == original_val

--- a/scripts/tests/test_processor.py
+++ b/scripts/tests/test_processor.py
@@ -3,7 +3,7 @@ import pytest
 import pandas as pd
 import numpy as np
 
-from scripts.processor import detect_outliers, process_data
+from scripts.processor import detect_outliers, process_data, correct_outliers
 
 
 def test_detect_outliers_basic():
@@ -68,3 +68,70 @@ def test_process_data_time_col_parsing_failure(caplog):
         "Time column 'Time (Seconds)' is not numeric and could not be converted"
         in caplog.text
     )
+
+
+def test_correct_outliers_empty_indices():
+    """Test when no outliers are provided."""
+    data = pd.DataFrame({"value": [1.0, 2.0, 3.0]})
+    result = correct_outliers(data, outlier_indices=[], value_col="value")
+    # Should return a copy, not the original object
+    assert result is not data
+    pd.testing.assert_frame_equal(result, data)
+
+
+def test_correct_outliers_remove():
+    """Test removing outliers (replaced with NaN)."""
+    data = pd.DataFrame({"value": [1.0, 100.0, 3.0]})
+    result = correct_outliers(
+        data, outlier_indices=[1], value_col="value", method="remove"
+    )
+    assert pd.isna(result.loc[1, "value"])
+    assert result.loc[0, "value"] == 1.0
+    assert result.loc[2, "value"] == 3.0
+
+
+def test_correct_outliers_interpolate():
+    """Test interpolating outliers."""
+    data = pd.DataFrame({"value": [1.0, 100.0, 3.0]})
+    result = correct_outliers(
+        data, outlier_indices=[1], value_col="value", method="interpolate"
+    )
+    assert result.loc[1, "value"] == 2.0  # (1.0 + 3.0) / 2
+    assert result.loc[0, "value"] == 1.0
+    assert result.loc[2, "value"] == 3.0
+
+
+def test_correct_outliers_median():
+    """Test replacing outliers with the median of the window."""
+    # window_size = 3 (padding = 1 on each side)
+    # Outlier at index 2 (100.0). Window is [2.0, NaN, 4.0] -> Median 3.0
+    data = pd.DataFrame({"value": [1.0, 2.0, 100.0, 4.0, 5.0]})
+    result = correct_outliers(
+        data, outlier_indices=[2], value_col="value", window_size=3, method="median"
+    )
+    assert result.loc[2, "value"] == 3.0
+
+    # window_size = 5 (padding = 2 on each side)
+    # Window is [1.0, 2.0, NaN, 4.0, 5.0] -> Median 3.0
+    result2 = correct_outliers(
+        data, outlier_indices=[2], value_col="value", window_size=5, method="median"
+    )
+    assert result2.loc[2, "value"] == 3.0
+
+
+def test_correct_outliers_mean():
+    """Test replacing outliers with the mean of the window."""
+    # window_size = 3 (padding = 1 on each side)
+    # Outlier at index 2. Window is [2.0, NaN, 4.0] -> Mean 3.0
+    data = pd.DataFrame({"value": [1.0, 2.0, 100.0, 4.0, 5.0]})
+    result = correct_outliers(
+        data, outlier_indices=[2], value_col="value", window_size=3, method="mean"
+    )
+    assert result.loc[2, "value"] == 3.0
+
+    # window_size = 3. Window [2.0, NaN, 10.0] -> Mean 6.0
+    data2 = pd.DataFrame({"value": [1.0, 2.0, 100.0, 10.0, 5.0]})
+    result3 = correct_outliers(
+        data2, outlier_indices=[2], value_col="value", window_size=3, method="mean"
+    )
+    assert result3.loc[2, "value"] == 6.0

--- a/scripts/tests/test_processor.py
+++ b/scripts/tests/test_processor.py
@@ -80,36 +80,76 @@ def test_correct_outliers_empty_indices():
 
 
 @pytest.mark.parametrize(
-    "method, window_size, data_vals, outlier_indices, expected_val, check_nan",
+    "test_case",
     [
-        ("remove", 3, [1.0, 100.0, 3.0], [1], None, True),
-        ("interpolate", 3, [1.0, 100.0, 3.0], [1], 2.0, False),
-        ("median", 3, [1.0, 2.0, 100.0, 4.0, 5.0], [2], 3.0, False),
-        ("median", 5, [1.0, 2.0, 100.0, 4.0, 5.0], [2], 3.0, False),
-        ("mean", 3, [1.0, 2.0, 100.0, 4.0, 5.0], [2], 3.0, False),
-        ("mean", 3, [1.0, 2.0, 100.0, 10.0, 5.0], [2], 6.0, False),
+        {
+            "method": "remove",
+            "window_size": 3,
+            "data_vals": [1.0, 100.0, 3.0],
+            "outlier_indices": [1],
+            "expected_val": None,
+            "check_nan": True,
+        },
+        {
+            "method": "interpolate",
+            "window_size": 3,
+            "data_vals": [1.0, 100.0, 3.0],
+            "outlier_indices": [1],
+            "expected_val": 2.0,
+            "check_nan": False,
+        },
+        {
+            "method": "median",
+            "window_size": 3,
+            "data_vals": [1.0, 2.0, 100.0, 4.0, 5.0],
+            "outlier_indices": [2],
+            "expected_val": 3.0,
+            "check_nan": False,
+        },
+        {
+            "method": "median",
+            "window_size": 5,
+            "data_vals": [1.0, 2.0, 100.0, 4.0, 5.0],
+            "outlier_indices": [2],
+            "expected_val": 3.0,
+            "check_nan": False,
+        },
+        {
+            "method": "mean",
+            "window_size": 3,
+            "data_vals": [1.0, 2.0, 100.0, 4.0, 5.0],
+            "outlier_indices": [2],
+            "expected_val": 3.0,
+            "check_nan": False,
+        },
+        {
+            "method": "mean",
+            "window_size": 3,
+            "data_vals": [1.0, 2.0, 100.0, 10.0, 5.0],
+            "outlier_indices": [2],
+            "expected_val": 6.0,
+            "check_nan": False,
+        },
     ],
 )
-def test_correct_outliers_methods(
-    method, window_size, data_vals, outlier_indices, expected_val, check_nan
-):
+def test_correct_outliers_methods(test_case):
     """Test correcting outliers using various methods."""
-    data = pd.DataFrame({"value": data_vals})
+    data = pd.DataFrame({"value": test_case["data_vals"]})
     result = correct_outliers(
         data,
-        outlier_indices=outlier_indices,
+        outlier_indices=test_case["outlier_indices"],
         value_col="value",
-        window_size=window_size,
-        method=method,
+        window_size=test_case["window_size"],
+        method=test_case["method"],
     )
 
-    idx = outlier_indices[0]
-    if check_nan:
+    idx = test_case["outlier_indices"][0]
+    if test_case["check_nan"]:
         assert pd.isna(result.loc[idx, "value"])
     else:
-        assert result.loc[idx, "value"] == expected_val
+        assert result.loc[idx, "value"] == test_case["expected_val"]
 
     # Verify that non-outlier values are unchanged
-    for i, original_val in enumerate(data_vals):
-        if i not in outlier_indices:
+    for i, original_val in enumerate(test_case["data_vals"]):
+        if i not in test_case["outlier_indices"]:
             assert result.loc[i, "value"] == original_val


### PR DESCRIPTION
🎯 **What:** The `correct_outliers` function in `scripts/processor.py` lacked unit test coverage for its outlier replacement logic (`method` variations). This left complex functionality (e.g., vectorized window calculation for mean/median replacements) untested and vulnerable to regressions.

📊 **Coverage:** Added test cases covering all supported outlier correction methods:
- `test_correct_outliers_empty_indices`: Ensures no operations occur when no outliers exist, returning a dataframe copy.
- `test_correct_outliers_remove`: Verifies replacing outliers with `NaN`.
- `test_correct_outliers_interpolate`: Verifies linear interpolation over the outlier window.
- `test_correct_outliers_median`: Verifies replacing outliers with the sliding window median (handling padding correctly).
- `test_correct_outliers_mean`: Verifies replacing outliers with the sliding window mean.

✨ **Result:** The `correct_outliers` core methods are thoroughly tested, establishing a safety net for future code modifications, ensuring proper window calculation, padding handling, and replacement strategies.

---
*PR created automatically by Jules for task [14550608160093074481](https://jules.google.com/task/14550608160093074481) started by @abhimehro*