### PR TITLE
🔒 Sentinel: [LOW] Fix raw exception data exposure in CLI output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** Calling `to_csv()` directly on Pandas DataFrames containing untrusted string or categorical columns allows malicious actors to inject Excel formulas (e.g., values starting with `=`, `+`, `-`, `@`) which execute when the CSV is opened in spreadsheet software.
 **Learning:** While `to_excel()` was explicitly protected by `write_excel_safely` in this codebase, exports to CSV via `to_csv()` were overlooked in scripts like `apply_refined_corrections.py` and `generate_overview_table.py`.
 **Prevention:** Always apply the existing `sanitize_dataframe_for_spreadsheet()` utility to DataFrames before any export (CSV or Excel) that might be opened in spreadsheet software. Created a centralized `write_csv_safely` utility alongside `write_excel_safely` to enforce this consistently.
+## 2025-02-24 - Fix raw exception data exposure in CLI output
+**Vulnerability:** Raw Exception Data Exposure (CWE-209). Exception objects and types were directly interpolated into user-facing `print()` statements.
+**Learning:** It's common to lazily print `e` in scripts, but this violates secure coding standards by leaking system state or implementation details to terminal output.
+**Prevention:** Never include exception objects (`{e}`) in `print()` statements. Use generalized warning messages for CLI output, and structured logging (`logging.exception`) if stack traces are required.

--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -135,23 +135,19 @@ def export_comparisons():
                 if cols:
                     cols[0] = "Time (Seconds)"
                 raw_df.columns = cols
-        except (IOError, ValueError) as e:
-            print(f"[WARN] Could not load raw file {raw_file}: {e}")
+        except (IOError, ValueError):
+            print(f"[WARN] Could not load raw file {raw_file}")
             continue
-        except Exception as e:
-            print(
-                f"[WARN] Unexpected error loading raw file {raw_file}: {type(e).__name__}: {e}"
-            )
+        except Exception:
+            print(f"[WARN] Unexpected error loading raw file {raw_file}")
             continue
         try:
             proc_df = read_excel(proc_file)
-        except (IOError, ValueError) as e:
-            print(f"[WARN] Could not load processed file {proc_file}: {e}")
+        except (IOError, ValueError):
+            print(f"[WARN] Could not load processed file {proc_file}")
             continue
-        except Exception as e:
-            print(
-                f"[WARN] Unexpected error loading processed file {proc_file}: {type(e).__name__}: {e}"
-            )
+        except Exception:
+            print(f"[WARN] Unexpected error loading processed file {proc_file}")
             continue
         # Store a reference to proc_df to show it's used in the function
         processed_df = proc_df  # Explicitly show this variable is used


### PR DESCRIPTION
🔒 Sentinel: [LOW] Fix raw exception data exposure in CLI output

🚨 Severity: LOW
💡 Vulnerability: Raw Exception Data Exposure (CWE-209). Unhandled exception details were being printed directly to CLI output when raw or processed files failed to load.
🎯 Impact: Minor. Exposing raw stack traces or internal object types can reveal implementation details to users, aiding potential reconnaissance.
🔧 Fix: Removed raw exception objects (`{e}` and `{type(e).__name__}`) from the print statements in `scripts/export_comparison_sheets.py`.
✅ Verification: Ran format, lint, and full test suite successfully.

========== ELIR ==========
PURPOSE: Prevent exposure of raw exception messages and types in CLI warnings.
SECURITY: Information Exposure (CWE-209). Prevents leaking internal state or file paths not explicitly intended for the user.
FAILS IF: A file truly fails to load, it now outputs a generic warning instead of the exact reason.
VERIFY: Run the script against a missing or malformed file; the warning should not contain `[Errno 2] No such file or directory...`
MAINTAIN: When handling exceptions for user-facing outputs, always sanitize or generalize the error. Keep raw exception tracking in standard logs using `log.exception` or `log.error`, not `print`.

---
*PR created automatically by Jules for task [4358575571668034763](https://jules.google.com/task/4358575571668034763) started by @abhimehro*