### PR TITLE
🧹 Catch (ValueError, KeyError) instead of broad Exception in apply_refined_corrections

### DIFF
--- a/scripts/apply_refined_corrections.py
+++ b/scripts/apply_refined_corrections.py
@@ -200,7 +200,7 @@ def apply_level_shift_correction(outlier_info, raw_file_map, raw_dataframes):
             "Rationale": f"Aligned Y{next_yy:02d} head with Y{prev_yy:02d} tail.",
         }
 
-    except Exception as e:
+    except (ValueError, KeyError) as e:
         print(f"Error processing outlier {year_pair_str}, {sensor_name}: {e}")
         return None
 


### PR DESCRIPTION
🎯 **What:** Replaced broad `except Exception as e:` with targeted `except (ValueError, KeyError) as e:` in `apply_level_shift_correction`.
💡 **Why:** Broad exception handling can hide unexpected errors (like typos or unhandled logic paths), making debugging difficult. Catching only the expected exceptions improves maintainability and visibility of unexpected issues.
✅ **Verification:** Ran the full test suite (`pytest scripts/tests/ -v`) and confirmed that all tests passed without regressions. Confirmed linting (flake8) and formatting (black) were unaffected.
✨ **Result:** The exception handling is now tighter and safer, without changing normal functional behavior.

---
*PR created automatically by Jules for task [3023767093527162293](https://jules.google.com/task/3023767093527162293) started by @abhimehro*