### PR TITLE
🧪 Add test for batch_correction config load FileNotFoundError

### DIFF
--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -663,3 +663,29 @@ def test_minimal_happy_path(monkeypatch):
     assert len(summary_df) == 2
     assert all(summary_df["Status"] == "Processed")
     assert set(summary_df["Filename"]) == set(file_list)
+
+
+def test_batch_process_config_not_found(mock_dependencies, mock_config_loader, caplog):
+    """
+    Test scenario where config file is not found.
+    """
+    mock_config_loader.side_effect = FileNotFoundError()
+
+    series_selection = 26
+    river_miles = None
+    years = (1995, 1995)
+    dry_run = True
+
+    # Act
+    from scripts.batch_correction import batch_process
+
+    batch_process(series_selection, river_miles, years, dry_run=dry_run)
+
+    # Assert
+    assert mock_config_loader.called
+    warning_logged = any(
+        "not found – continuing with empty config." in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+    assert warning_logged


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `scripts/tests/test_batch_correction.py` to cover the scenario where `load_config_func` raises a `FileNotFoundError` during the execution of `batch_process` in `scripts/batch_correction.py`.

📊 **Coverage:** The test explicitly verifies the error path. By mocking the `mock_config_loader` fixture to raise `FileNotFoundError()`, it confirms that the exception is caught correctly and the application continues gracefully with an empty configuration while logging the required "not found – continuing with empty config." warning via the `caplog` fixture.

✨ **Result:** Improved test reliability and ensured that expected resilience mechanisms correctly activate during configuration file absences. Tests run and pass without altering existing behaviors.

---
*PR created automatically by Jules for task [9940998494884138336](https://jules.google.com/task/9940998494884138336) started by @abhimehro*