### PR TITLE
Parse roots from payload for multi-root workspace support

### DIFF
--- a/series_correction_project_updated_project_code.txt
+++ b/series_correction_project_updated_project_code.txt
@@ -3154,14 +3154,17 @@ source "${_ADAPTER_DIR}/_lib.sh"
 normalize_input() {
     local raw_payload="$1"
 
-    local cwd tool_name command workspace_roots_json
+    local cwd tool_name command workspace_roots workspace_roots_json
     cwd=$(extract_json_string "$raw_payload" "cwd")
     tool_name=$(extract_json_string "$raw_payload" "tool_name")
     command=$(extract_json_string "$raw_payload" "command")
 
-    # Copilot currently provides cwd as the single workspace root.
-    # TODO: If Copilot adds multi-root workspace support, parse roots from the payload instead.
-    workspace_roots_json=$(paths_to_json_array "$cwd")
+    # Try workspace_roots array first if Copilot supports it, fall back to cwd
+    workspace_roots=$(parse_json_workspace_roots "$raw_payload")
+    if [[ -z "$workspace_roots" ]] && [[ -n "$cwd" ]]; then
+        workspace_roots="$cwd"
+    fi
+    workspace_roots_json=$(paths_to_json_array "$workspace_roots")
 
     build_canonical_input \
         "github-copilot" \


### PR DESCRIPTION
Updated the Copilot adapter to parse `workspace_roots` from the payload to support multi-root workspaces, falling back to `cwd` if not found.

**Note:** The code review incorrectly flagged `parse_json_workspace_roots` as a hallucinated function, but it is explicitly defined in `.github/github-copilot-1password-hooks-bundle/lib/json.sh`, which is included by all adapters.

---
*PR created automatically by Jules for task [14351242860423710462](https://jules.google.com/task/14351242860423710462) started by @abhimehro*