### PR TITLE
perf(outliers): reuse rolling_median in MAD calculation (salvages #204)

### DIFF
--- a/scripts/discontinuity_utils.py
+++ b/scripts/discontinuity_utils.py
@@ -172,7 +172,8 @@ def _calculate_outlier_z_scores(values_np, rolling_median, window_size, threshol
         cw = sliding_window_view(
             values_np[s : e + window_size - 1], window_shape=window_size
         )
-        cm = np.nanmedian(cw, axis=1, keepdims=True)
+        pad = window_size // 2
+        cm = rolling_median[s + pad : e + pad, np.newaxis]
         cmads = np.nanmedian(np.abs(cw - cm), axis=1)
         cmads[np.isnan(cw).sum(axis=1) > 0] = np.nan
         mads.append(cmads)

--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -78,7 +78,11 @@ def detect_outliers_series(values, window_size=5, threshold=3.0):
             nan_counts = np.isnan(chunk_windows).sum(axis=1)
             invalid_mask = nan_counts > 0
 
-            chunk_medians = np.nanmedian(chunk_windows, axis=1, keepdims=True)
+            # Reuse precomputed rolling_median instead of recalculating np.nanmedian per window.
+            pad = window_size // 2
+            chunk_medians = rolling_median[
+                start_idx + pad : end_idx + pad, np.newaxis
+            ]
             chunk_abs_diffs = np.abs(chunk_windows - chunk_medians)
             chunk_mads = np.nanmedian(chunk_abs_diffs, axis=1)
 


### PR DESCRIPTION
## Summary

Salvages the performance intent from Jules Bolt PR #204 without the bundled `processor.py` refactor that made the original branch `DIRTY`.

**Changes:**
- `scripts/export_comparison_sheets.py` — reuse precomputed `rolling_median` slices instead of `np.nanmedian` per sliding window
- `scripts/discontinuity_utils.py` — same optimization in `_calculate_outlier_z_scores`

**Verification:** `python3 -m pytest scripts/tests/ -v` — 58 passed

Closes superseded original: #204

═══ ELIR ═══
**PURPOSE:** Eliminate redundant median recomputation in MAD outlier detection (~45% faster per Jules benchmark).
**SECURITY:** Pure numerical optimization; no trust-boundary changes.
**FAILS IF:** Index alignment between `rolling_median` and sliding windows drifts — mitigated by existing test suite.
**VERIFY:** Run `pytest scripts/tests/test_export_comparison_sheets.py scripts/tests/test_processor.py -v`.
**MAINTAIN:** If `window_size` or `center=True` rolling semantics change, re-validate the `pad` offset math in both files.