### PR TITLE
⚡ Bolt: Cache os.listdir in _find_year_file_match

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 ## 2025-07-04 - Vectorize Pandas Time-Series Differences
 **Learning:** Using Pandas `.diff()` and `.median()` along with boolean index filtering incurs significant overhead from Series instantiation, block manager operations, and index alignment.
 **Action:** When calculating element-wise differences and filtering based on the median in performance-critical code, extract the underlying NumPy array (`.to_numpy()`) and use `np.diff()`, `np.median()`, and `np.where()`. This avoids Pandas overhead and provides a substantial (~35%) speedup. Since `np.diff` returns an array of length N-1, remember to adjust positional indices (e.g., `+ 1`) to map back to the original array correctly.
+
+## 2025-07-06 - Optimize redundant directory listings
+**Learning:** Calling `os.listdir()` repeatedly inside loops or repeatedly called functions (like searching for matches file by file) causes significant I/O overhead.
+**Action:** When searching a directory that remains static during execution, cache the `os.listdir()` results in memory. For clean state encapsulation, attach the cache to the function object itself (e.g., `func._cache`) on the first call to avoid redundant I/O operations and substantially improve performance without polluting the global namespace.

--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -34,7 +34,9 @@ def _find_year_file_match(processed_filename):
     m = re.search(r"Year_(\d+) \(Y(\d+)\)_Data", processed_filename)
     if m:
         yidx = int(m.group(2))
-        for f in os.listdir(RAW_DATA_DIR):
+        if not hasattr(_find_year_file_match, "_cache"):
+            _find_year_file_match._cache = os.listdir(RAW_DATA_DIR)
+        for f in _find_year_file_match._cache:
             if f.endswith(f"_Y{yidx:02d}.txt"):
                 return os.path.join(RAW_DATA_DIR, f)
     return None
@@ -80,9 +82,7 @@ def detect_outliers_series(values, window_size=5, threshold=3.0):
 
             # Reuse precomputed rolling_median instead of recalculating np.nanmedian per window.
             pad = window_size // 2
-            chunk_medians = rolling_median[
-                start_idx + pad : end_idx + pad, np.newaxis
-            ]
+            chunk_medians = rolling_median[start_idx + pad : end_idx + pad, np.newaxis]
             chunk_abs_diffs = np.abs(chunk_windows - chunk_medians)
             chunk_mads = np.nanmedian(chunk_abs_diffs, axis=1)
 

--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -32,13 +32,16 @@ def _find_year_file_match(processed_filename):
     import re
 
     m = re.search(r"Year_(\d+) \(Y(\d+)\)_Data", processed_filename)
-    if m:
-        yidx = int(m.group(2))
-        if not hasattr(_find_year_file_match, "_cache"):
-            _find_year_file_match._cache = os.listdir(RAW_DATA_DIR)
-        for f in _find_year_file_match._cache:
-            if f.endswith(f"_Y{yidx:02d}.txt"):
-                return os.path.join(RAW_DATA_DIR, f)
+    if not m:
+        return None
+
+    yidx = int(m.group(2))
+    if not hasattr(_find_year_file_match, "_cache"):
+        _find_year_file_match._cache = os.listdir(RAW_DATA_DIR)
+
+    for f in _find_year_file_match._cache:
+        if f.endswith(f"_Y{yidx:02d}.txt"):
+            return os.path.join(RAW_DATA_DIR, f)
     return None
 
 


### PR DESCRIPTION
💡 What: Attached an `_cache` attribute to the `_find_year_file_match` function to store the list of files in `RAW_DATA_DIR` during the first call, and reuse it for subsequent calls.
🎯 Why: `_find_year_file_match` was calling `os.listdir(RAW_DATA_DIR)` every time it was invoked. This causes repeated O(N) directory scans which dramatically slows down processing for large datasets.
📊 Impact: Substantially speeds up matching processed files to their corresponding raw files by avoiding redundant I/O operations.
🔬 Measurement: Verify the change by running the test suite (`python3 -m pytest scripts/tests/ -v`). The logic matches the original, but runs significantly faster when processing multiple files.

---
*PR created automatically by Jules for task [16168108038629201102](https://jules.google.com/task/16168108038629201102) started by @abhimehro*