### PR TITLE
🧹 Suppress RuntimeWarnings for np.nanmedian when processing all-NaN slices

### DIFF
--- a/scripts/discontinuity_utils.py
+++ b/scripts/discontinuity_utils.py
@@ -1,3 +1,5 @@
+import warnings
+
 """
 Utility functions for discontinuity processing in the Series Correction Project.
 
@@ -174,7 +176,11 @@ def _calculate_outlier_z_scores(values_np, rolling_median, window_size, threshol
         )
         pad = window_size // 2
         cm = rolling_median[s + pad : e + pad, np.newaxis]
-        cmads = np.nanmedian(np.abs(cw - cm), axis=1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            cmads = np.nanmedian(np.abs(cw - cm), axis=1)
+
         cmads[np.isnan(cw).sum(axis=1) > 0] = np.nan
         mads.append(cmads)
 

--- a/scripts/export_comparison_sheets.py
+++ b/scripts/export_comparison_sheets.py
@@ -5,6 +5,7 @@ import numpy as np
 from pandas import concat, merge, read_csv, read_excel
 
 from scripts.spreadsheet_safety import write_excel_safely
+import warnings
 
 RAW_DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
 OUTPUT_DIR = os.path.abspath(
@@ -80,11 +81,12 @@ def detect_outliers_series(values, window_size=5, threshold=3.0):
 
             # Reuse precomputed rolling_median instead of recalculating np.nanmedian per window.
             pad = window_size // 2
-            chunk_medians = rolling_median[
-                start_idx + pad : end_idx + pad, np.newaxis
-            ]
+            chunk_medians = rolling_median[start_idx + pad : end_idx + pad, np.newaxis]
             chunk_abs_diffs = np.abs(chunk_windows - chunk_medians)
-            chunk_mads = np.nanmedian(chunk_abs_diffs, axis=1)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=RuntimeWarning)
+                chunk_mads = np.nanmedian(chunk_abs_diffs, axis=1)
 
             # Invalidate windows that contain any NaNs, matching the pandas rolling behavior
             chunk_mads[invalid_mask] = np.nan


### PR DESCRIPTION
🎯 What:
Wrapped `np.nanmedian` with `warnings.catch_warnings` to suppress `RuntimeWarning` when calculating cmads and chunk_mads.

💡 Why:
There is an issue where `RuntimeWarning: All-NaN slice encountered` pollutes standard output or test logs when `np.nanmedian` is applied to an array/slice containing only `NaN` values. The patch wraps these specific `np.nanmedian` calls with a context manager to suppress the warning, correctly addressing the issue.

✅ Verification:
- Tests pass cleanly without warnings.
- Code is properly formatted.
- Code review complete and imports moved to module top.

✨ Result:
Cleaner test logs and console output. No new issues found.

---
*PR created automatically by Jules for task [1287704877213536401](https://jules.google.com/task/1287704877213536401) started by @abhimehro*