### PR TITLE
🧹 fix(lint): resolve Ruff E402 formatting issue in discontinuity_utils.py

### DIFF
--- a/scripts/discontinuity_utils.py
+++ b/scripts/discontinuity_utils.py
@@ -1,11 +1,10 @@
-import warnings
-
 """
 Utility functions for discontinuity processing in the Series Correction Project.
 
 Extracted from processor.py to reduce file size and improve maintainability.
 """
 
+import warnings
 import logging
 from dataclasses import dataclass
 from typing import Any


### PR DESCRIPTION
## Summary
Resolves Ruff E402 ("Module level import not at top of file") in `scripts/discontinuity_utils.py` by placing the module-level docstring at the very top of the file, before `import warnings`. Reformatted the file with Black.

## Findings from Daily Agentic QA Review
- **Build & Tests**: Codebase builds and runs successfully. All 58 tests pass (`pytest scripts/tests -v`).
- **Code Quality**: `flake8`, `black`, and `ruff` checks pass cleanly after the fix.
- **Historical Check**: PRs #49 and #50 already addressed recent F401 linting issues and are merged/closed. No other relevant open issues found.
- **Actionable Insights**: The repository is fully healthy after this minor formatting fix.

## Bash Commands Used During Verification
```bash
PYTHONPATH=$(pwd) python3 -m pytest scripts/tests/ -v
flake8 scripts/ --max-line-length=100
black scripts/ --check
ruff check scripts
```

---
*PR created automatically by Jules for task [10276545244620402955](https://jules.google.com/task/10276545244620402955) started by @abhimehro*