### PR TITLE
docs(agents): document egg-info hygiene from continual learning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,11 @@ During automated PR review or salvage sessions, if CodeScene is red on a PR, pos
 ```
 
 Then wait for that run to complete before final defer/salvage disposition.
+
+## Learned User Preferences
+
+- Do not commit local editable-install build metadata when finishing unrelated sessions.
+
+## Learned Workspace Facts
+
+- `seatek_series_correction.egg-info/` is still tracked despite `*.egg-info/` in `.gitignore`; editable installs dirty those files—restore with `git checkout -- seatek_series_correction.egg-info/` and never stage them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continual-learning note for this repo: editable installs dirty tracked `seatek_series_correction.egg-info/` even though `*.egg-info/` is gitignored for new paths — restore those files and never stage them.

## Changes

- **Learned User Preferences:** Do not commit local editable-install build metadata when finishing unrelated sessions.
- **Learned Workspace Facts:** Document `git checkout -- seatek_series_correction.egg-info/` recovery and never-stage rule.

## Test plan

- [ ] Confirm guidance matches observed dirt after `pip install -e .`
- [ ] No code or egg-info files changed in this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-291ed5fb-e755-417e-86cd-57fc49d6aeb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-291ed5fb-e755-417e-86cd-57fc49d6aeb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

