### PR TITLE
Draft: Salvage #235 integer column rename optimization

### DIFF
--- a/scripts/batch_correction.py
+++ b/scripts/batch_correction.py
@@ -343,11 +343,13 @@ def _load_raw_data(file_path):
         df = pd.DataFrame({col: _safe_numeric(df[col]) for col in df.columns})
 
         # Nice column names: first col is time, rest ValueX
-        if all(isinstance(c, int) for c in df.columns):
-            cols = [f"Value{i + 1}" for i in range(len(df.columns))]
-            if cols:
-                cols[0] = "Time (Seconds)"
-            df.columns = cols
+        if pd.api.types.is_integer_dtype(df.columns):
+            n = len(df.columns)
+            if n > 0:
+                df.columns = [
+                    "Time (Seconds)",
+                    *[f"Value{i}" for i in range(2, n + 1)],
+                ]
         return df
     except pd.errors.EmptyDataError:
         log.debug(f"File {file_path} empty.")


### PR DESCRIPTION
## ELIR
- Evidence: Salvages the is_integer_dtype column rename optimization from #235.
- Lineage: Supersedes #235; journal and import-order-only hunks were skipped.
- Implementation: Uses pd.api.types.is_integer_dtype(df.columns) and constructs the target column list directly.
- Risk: Low; preserves the Time/Value2..ValueN naming behavior.

## Verification
- python3 -m pytest scripts/tests/ -q — 58 passed.
