### PR TITLE
🧪 [Testing Improvement] Add tests for calculate_non_zero_average

### DIFF
--- a/scripts/tests/test_apply_refined_corrections.py
+++ b/scripts/tests/test_apply_refined_corrections.py
@@ -154,3 +154,28 @@ def test_load_identified_outliers_missing_columns(tmp_path, capsys, test_case):
 
     captured = capsys.readouterr()
     assert f"{expected_error_fragment} {csv_file}." in captured.out
+
+
+def test_calculate_non_zero_average_booleans():
+    """Test with boolean values (True coerced to 1, False to 0)."""
+    series = pd.Series([True, False, True])
+    assert calculate_non_zero_average(series) == 1.0
+
+
+def test_calculate_non_zero_average_inf():
+    # mean of [inf, -inf, 1.0] gives NaN and triggers RuntimeWarning,
+    # let's just test with a single inf and 1.0 to get inf.
+    series = pd.Series([np.inf, 1.0])
+    assert np.isinf(calculate_non_zero_average(series))
+
+
+def test_calculate_non_zero_average_whitespace():
+    """Test with whitespace strings which become NaN."""
+    series = pd.Series(["", " ", "1.0"])
+    assert calculate_non_zero_average(series) == 1.0
+
+
+def test_calculate_non_zero_average_complex_objects():
+    """Test with uncoercible complex objects."""
+    series = pd.Series([[1], {"a": 1}, 2.0])
+    assert calculate_non_zero_average(series) == 2.0


### PR DESCRIPTION
🎯 What: Added missing tests for the calculate_non_zero_average function to cover pandas coerce edge cases (booleans, infinity, whitespace strings, and complex objects).
📊 Coverage: Added tests for boolean coercion (True/False), infinite values handling, whitespace string coercion to NaN, and uncoercible complex object behaviors.
✨ Result: Increased test reliability and explicit documentation of pd.to_numeric edge case behavior through tests.

---
*PR created automatically by Jules for task [1970371774115368483](https://jules.google.com/task/1970371774115368483) started by @abhimehro*