### PR TITLE
🔒 Fix unsafe absolute path usage in run_analysis.py

### DIFF
--- a/scripts/run_analysis.py
+++ b/scripts/run_analysis.py
@@ -5,7 +5,8 @@ import os
 from scripts.batch_correction import batch_process
 
 # Use direct, absolute paths
-PROJECT_PATH = "/Users/abhimehrotra/PycharmProjects/series_correction_project_updated"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_PATH = os.path.dirname(SCRIPT_DIR)
 CONFIG_PATH = os.path.join(PROJECT_PATH, "scripts", "config.json")
 OUTPUT_DIR = os.path.join(PROJECT_PATH, "data", "output")
 


### PR DESCRIPTION
🎯 What:
Replaced a hardcoded absolute path (`PROJECT_PATH = "/Users/..."`) in `scripts/run_analysis.py` with a dynamically calculated path relative to the script's location.

⚠️ Risk:
Using a hardcoded absolute path makes the script extremely brittle, causing it to break when executed on any machine other than the original author's. Additionally, it leaks information about the local user directory structure (e.g., username, file organization) which is a mild security risk and an anti-pattern.

🛡️ Solution:
Utilized `os.path.dirname(os.path.abspath(__file__))` to determine the script's runtime directory, and derived the `PROJECT_PATH` by resolving its parent directory. This ensures the configuration and output directories are always resolved correctly regardless of where the repository is cloned.

---
*PR created automatically by Jules for task [9786193416322952231](https://jules.google.com/task/9786193416322952231) started by @abhimehro*