### PR TITLE
🔒 Fix unsafe absolute path usage in run_analysis.py

### DIFF
--- a/scripts/run_analysis.py
+++ b/scripts/run_analysis.py
@@ -5,7 +5,8 @@ import os
 from scripts.batch_correction import batch_process
 
 # Use direct, absolute paths
-PROJECT_PATH = "/Users/abhimehrotra/PycharmProjects/series_correction_project_updated"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_PATH = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
 CONFIG_PATH = os.path.join(PROJECT_PATH, "scripts", "config.json")
 OUTPUT_DIR = os.path.join(PROJECT_PATH, "data", "output")
 


### PR DESCRIPTION
🎯 What: Replaced a hardcoded absolute path (`PROJECT_PATH = '/Users/abhimehrotra/PycharmProjects/series_correction_project_updated'`) with dynamic path resolution based on the script's location (`__file__`).
⚠️ Risk: The hardcoded absolute path broke the script on any machine other than the original developer's, preventing execution in different environments (like CI/CD or other developers' local machines). This path could also inadvertently expose the structure of the developer's filesystem.
🛡️ Solution: Used `os.path.dirname` and `os.path.abspath(__file__)` to dynamically determine the `SCRIPT_DIR` and relative `PROJECT_PATH`. This ensures the paths for config and output directories are correctly resolved relative to where the script is executed from, regardless of the host system.

---
*PR created automatically by Jules for task [15493095355066736475](https://jules.google.com/task/15493095355066736475) started by @abhimehro*