### PR TITLE
🧪 [testing improvement] Add EmptyDataError test for _load_raw_data

### DIFF
--- a/scripts/tests/test_batch_correction.py
+++ b/scripts/tests/test_batch_correction.py
@@ -689,3 +689,20 @@ def test_batch_process_config_not_found(mock_dependencies, mock_config_loader, c
         if record.levelname == "WARNING"
     )
     assert warning_logged
+
+
+def test_load_raw_data_empty_file(caplog):
+    """Test that _load_raw_data handles EmptyDataError correctly."""
+    caplog.set_level("DEBUG")
+    from scripts.batch_correction import _load_raw_data
+
+    with mock.patch("pandas.read_csv") as mock_read_csv:
+        mock_read_csv.side_effect = pd.errors.EmptyDataError(
+            "No columns to parse from file"
+        )
+
+        result = _load_raw_data("dummy_empty_file.txt")
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty
+        assert "dummy_empty_file.txt empty." in caplog.text


### PR DESCRIPTION
🎯 **What:** The `_load_raw_data` function in `scripts/batch_correction.py` lacked a unit test verifying its behavior when encountering an empty file (which throws `pd.errors.EmptyDataError`).
📊 **Coverage:** A test `test_load_raw_data_empty_file` was added to `scripts/tests/test_batch_correction.py` that mocks `pandas.read_csv` to raise `pd.errors.EmptyDataError` and asserts that the function catches it, logs appropriately, and returns an empty DataFrame as expected.
✨ **Result:** Test coverage improved, ensuring future refactoring won't accidentally break the empty-file fallback mechanism.

---
*PR created automatically by Jules for task [15297124454817889188](https://jules.google.com/task/15297124454817889188) started by @abhimehro*