### PR TITLE
🔒 Fix unsafe path interpretation in raw dataframe loading

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -1,6 +1,6 @@
 ========== ELIR ==========
-PURPOSE: Removed raw exception interpolation from `print` statements in `scripts/apply_refined_corrections.py` to prevent data leakage.
-SECURITY: Addresses Raw Exception Data Exposure. Prevents internal system details or underlying file paths contained in error messages from leaking to console output.
-FAILS IF: A specialized tool expected the console output to contain exact parsed exception text (unlikely for this script, but a general concern).
-VERIFY: Confirm the two modified `except Exception:` blocks log generic, static string errors without raw `{e}`.
-MAINTAIN: Ensure future additions to exception handling emit static, obfuscated strings rather than dynamic internal data.
+PURPOSE: Fixes unsafe dynamic path interpretation by Pandas `read_csv` when loading raw data files.
+SECURITY: Bypasses Pandas' internal path parser (which can resolve URLs or invoke external handlers based on extensions) by explicitly opening the file locally and passing the file object stream. This prevents potential SSRF or command execution vulnerabilities that could arise from an attacker dropping specially-named files into the target directory.
+FAILS IF: The file isn't actually accessible locally or has a different encoding.
+VERIFY: Ensure that `open(file_path)` correctly loads the file and `pd.read_csv` accepts the file object and parses the tab-separated content correctly.
+MAINTAIN: Always pass file objects instead of path strings to `read_csv` when handling files derived from external inputs or untrusted directories.

--- a/scripts/apply_refined_corrections.py
+++ b/scripts/apply_refined_corrections.py
@@ -102,7 +102,8 @@ def load_raw_dataframes(raw_file_map):
     for year_files in raw_file_map.values():
         for file_path in year_files.values():
             if file_path not in dataframes:
-                dataframes[file_path] = pd.read_csv(file_path, header=None, sep=r"\s+")
+                with open(file_path, "r", encoding="utf-8") as f:
+                    dataframes[file_path] = pd.read_csv(f, header=None, sep=r"\s+")
     return dataframes
 
 


### PR DESCRIPTION
🎯 What:
Changed `load_raw_dataframes` to open files using python's built-in `open()` rather than passing file paths as strings directly to `pd.read_csv`. Included ELIR handoff summary.

⚠️ Risk:
Passing string paths directly to `pd.read_csv` is potentially unsafe because pandas evaluates string paths dynamically. If it encounters URL-like strings or specific extensions, it may attempt to download resources or invoke external handlers (which could lead to SSRF or code execution vulnerabilities). Because the paths here come from an unfiltered directory scan, an attacker who could drop an interestingly named file into the data directory could exploit this parsing logic.

🛡️ Solution:
By explicitly opening the file locally using the built-in `open()` context manager and passing the resulting file object to pandas, we bypass pandas' dynamic path-interpretation mechanism completely, forcing it to consume the file stream directly without trying to evaluate the "path" string itself.

---
*PR created automatically by Jules for task [13872933457087201268](https://jules.google.com/task/13872933457087201268) started by @abhimehro*